### PR TITLE
Fix a Safari-specific bug where we'd erroneously null out a participa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/daily-js",
-  "version": "0.9.983",
+  "version": "0.9.984",
   "engines": {
     "node": ">=10.0.0"
   },

--- a/src/module.js
+++ b/src/module.js
@@ -1163,7 +1163,7 @@ export default class DailyIframe extends EventEmitter {
     try {
       let sp = state.participants[p.session_id];
       if (sp && sp.public.rtcType.impl === 'peer-to-peer') {
-        if (sp.private && sp.private.peeringState !== 'connected') {
+        if (sp.private && !['connected', 'completed'].includes(sp.private.peeringState)) {
           connected = false;
         }
       }


### PR DESCRIPTION
…nt's media tracks as though they were disconnected because we weren't handling the peeringState going to "completed" without going through "connected" (something we don't see in other browsers).