### PR TITLE
Add a `supportsScreenShare` field to the object returned by `supporte…

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -212,12 +212,17 @@ export default class DailyIframe extends EventEmitter {
               safari: ">=12",
               edge: "<0",
             }
-          });
+          }),
+          isScreenShareSupported = isValidBrowser && 
+            // The following is the exact screen share compatibility check the site uses
+            navigator.userAgent.match(/Chrome\//) && 
+            !navigator.userAgent.match(/Edge\//);
     return {
       supported: isValidBrowser,
       mobile: parsed.platform.type === 'mobile',
       name: basic.name,
       version: basic.version,
+      supportsScreenShare: isScreenShareSupported
       // basic, parsed
     };
   }


### PR DESCRIPTION
…dBrowser()`.

I know that we're hoping to expand our set of supported screen-sharable browsers soon. This gives customer code a way of determining whether they should enable screen share buttons.

Follow-up work when this is merged:

- [ ] Bump and update `daily-js` on npm & unpkg
- [ ] Update React demo code to use this method
- [ ] Update React blog post draft to recommend the functionality in this PR rather than reinventing the wheel