### PR TITLE
Active speaker mode control

### DIFF
--- a/src/CommonIncludes.js
+++ b/src/CommonIncludes.js
@@ -39,6 +39,7 @@ export const DAILY_EVENT_LOCAL_SCREEN_SHARE_STARTED =
 export const DAILY_EVENT_LOCAL_SCREEN_SHARE_STOPPED =
   'local-screen-share-stopped';
 export const DAILY_EVENT_ACTIVE_SPEAKER_CHANGE = 'active-speaker-change';
+export const DAILY_EVENT_ACTIVE_SPEAKER_MODE_CHANGE = 'active-speaker-mode-change';
 export const DAILY_EVENT_NETWORK_QUALITY_CHANGE = 'network-quality-change';
 export const DAILY_EVENT_NETWORK_CONNECTION = 'network-connection';
 

--- a/src/CommonIncludes.js
+++ b/src/CommonIncludes.js
@@ -77,6 +77,7 @@ export const DAILY_METHOD_CYCLE_MIC = 'cycle-mic';
 export const DAILY_METHOD_APP_MSG = 'app-msg';
 export const DAILY_METHOD_ADD_FAKE_PARTICIPANT = 'add-fake-participant';
 export const DAILY_METHOD_SET_SHOW_NAMES = 'set-show-names';
+export const DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE = 'set-active-speaker-mode';
 export const DAILY_METHOD_REGISTER_INPUT_HANDLER = 'register-input-handler';
 export const DAILY_METHOD_SET_LANG = 'set-daily-lang';
 export const DAILY_METHOD_DETECT_ALL_FACES = 'detect-all-faces';

--- a/src/module.js
+++ b/src/module.js
@@ -70,6 +70,7 @@ import {
   DAILY_METHOD_APP_MSG,
   DAILY_METHOD_ADD_FAKE_PARTICIPANT,
   DAILY_METHOD_SET_SHOW_NAMES,
+  DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE,
   DAILY_METHOD_SET_LANG,
   MAX_APP_MSG_SIZE,
   DAILY_METHOD_REGISTER_INPUT_HANDLER,
@@ -785,6 +786,11 @@ export default class DailyIframe extends EventEmitter {
 
   addFakeParticipant(args) {
     this._sendIframeMsg({ action: DAILY_METHOD_ADD_FAKE_PARTICIPANT, ...args });
+    return this;
+  }
+
+  setActiveSpeakerMode(enabled) {
+    this._sendIframeMsg({ action: DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE, enabled });
     return this;
   }
 


### PR DESCRIPTION
See the [Notion task](https://www.notion.so/dailyco/Make-Active-Speaker-Mode-controllable-via-the-JavaScript-API-efe8382a7b454e3db67cceee7217dc06) for context.

# Coupled change

https://github.com/kwindla/pluot-core/pull/1357

# Tests

- [x] Verify it updates the behavior of the iframe call (button, tiles)
- [x] Verify no-op when not currently in a meeting (doesn’t change value or fire event)
- [x] Verify no-op when setting value it already has (doesn’t fire event)
- [x] Verify value is reset to false on leave()
- [x] Verify is no-op when using with custom CSS
- [x] Verify is no-op when using with call object
- [x] Verify no active speaker related events fire on join() or leave()

# Follow-up

- [ ] Deploy
- [ ] Update documentation (per the [Notion task](https://www.notion.so/dailyco/Make-Active-Speaker-Mode-controllable-via-the-JavaScript-API-efe8382a7b454e3db67cceee7217dc06))