### PR TITLE
Bump version to 0.9.985

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/daily-js",
-  "version": "0.9.984",
+  "version": "0.9.985",
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
In preparation for deploying version of `daily-js` that provides programmatic control over active speaker mode.

Depends on latest `pluot-core` being deployed first.