### PR TITLE
Use CDN to fetch call-machine-object in prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5986,9 +5986,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "slash": {
@@ -7369,9 +7369,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
-      "integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
+      "integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
@@ -7515,9 +7515,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -973,6 +973,89 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.2.tgz",
+      "integrity": "sha512-KEEL7V2tMNOsbAoNMKg91l1sNXBDoiP31GFlqXVOuV5691VQKzKBh91+OKKOG4uQWYqcFskcjFyh1d5YnZd0Zw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "magic-string": "^0.25.5"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        }
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.9.tgz",
+      "integrity": "sha512-TLZavlfPAZYI7v33wQh4mTP6zojne14yok3DNSLcjoG/Hirxfkonn6icP5rrNWRn8nZsirJBFFpijVOJzkUHDg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -5036,6 +5119,12 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/daily-js",
-  "version": "0.9.97",
+  "version": "0.9.988",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/daily-js",
-  "version": "0.9.987",
+  "version": "0.9.988",
   "engines": {
     "node": ">=10.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.4",
     "webpack": "^4.41.5",
-    "webpack-cli": "^3.3.10"
+    "webpack-cli": "^3.3.11"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
+    "@rollup/plugin-replace": "^2.3.2",
     "babel-cli": "^6.26.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 
+import replace from '@rollup/plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
 import commonJS from 'rollup-plugin-commonjs'
 import { terser } from 'rollup-plugin-terser';
@@ -14,6 +15,9 @@ export default [
     plugins: [
       resolve({
         preferBuiltins: false
+      }),
+      replace({
+            'process.env.NODE_ENV': JSON.stringify('production')
       }),
       commonJS({
         include: 'node_modules/**',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonJS from 'rollup-plugin-commonjs'
 import { terser } from 'rollup-plugin-terser';
 
-const production = process.env.NODE_ENV !== 'development';
+const production = process.env.NODE_ENV || 'production';
 
 export default [
   {
@@ -17,7 +17,7 @@ export default [
         preferBuiltins: false
       }),
       replace({
-            'process.env.NODE_ENV': JSON.stringify('production')
+            'process.env.NODE_ENV': JSON.stringify(production)
       }),
       commonJS({
         include: 'node_modules/**',

--- a/src/module.js
+++ b/src/module.js
@@ -639,8 +639,8 @@ export default class DailyIframe extends EventEmitter {
             this._meetingState = DAILY_STATE_LOADED;
             resolve();
           }
-          // Use the CDN to get call-machine-object (but use whatever's "local" for dev)
-          if (process.env.NODE_ENV !== 'development') {
+          // Use the CDN to get call-machine-object (but use whatever's "local" for dev+staging)
+          if (process.env.NODE_ENV === 'production') {
             script.src = `https://c.daily.co/static/call-machine-object-bundle.js`;
           } else {
             let url = new URL(this.properties.url);

--- a/src/module.js
+++ b/src/module.js
@@ -639,8 +639,13 @@ export default class DailyIframe extends EventEmitter {
             this._meetingState = DAILY_STATE_LOADED;
             resolve();
           }
-          let url = new URL(this.properties.url);
-          script.src = `${url.origin}/static/call-machine-object-bundle.js`;
+          // Use the CDN to get call-machine-object (but use whatever's "local" for dev)
+          if (process.env.NODE_ENV !== 'development') {
+            script.src = `https://c.daily.co/static/call-machine-object-bundle.js`;
+          } else {
+            let url = new URL(this.properties.url);
+            script.src = `${url.origin}/static/call-machine-object-bundle.js`;
+          }
           head.appendChild(script);
         }
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 // todo: add debug target
 
 const path = require('path');
+const webpack = require('webpack');
 const mode = process.env.NODE_ENV || 'production';
 
 const bundle = {
@@ -14,6 +15,13 @@ const bundle = {
     libraryTarget: 'umd',
     globalObject: 'this'
   },
+  plugins: [
+    new webpack.DefinePlugin({
+        'process.env': {
+            'NODE_ENV': JSON.stringify(mode)
+        }
+    }),
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
### Description

In production only, use the CDN to fetch `call-machine-object-bundle.js`. In other environments, use the relative path to deliver whatever is local (i.e. from the dev server running on your machine).

This requires pushing the build-time `NODE_ENV` env var down so we can access it at runtime in  `module.js`. Webpack's `DefinePlugin` handles this nicely for us so the code remains intuitive when the check occurs.

### References

Matching PR in `pluot-core` to handle the other places we pull down call-machine: https://github.com/kwindla/pluot-core/pull/1373

Project card in Notion: https://www.notion.so/dailyco/Get-thee-to-a-CDN-call-machine-bundle-js-5645f07aeed34bdbaa5ef734c160ab2d