### PR TITLE
add API event for recording data

### DIFF
--- a/src/CommonIncludes.js
+++ b/src/CommonIncludes.js
@@ -32,6 +32,7 @@ export const DAILY_EVENT_RECORDING_STATS = 'recording-stats';
 export const DAILY_EVENT_RECORDING_ERROR = 'recording-error';
 export const DAILY_EVENT_RECORDING_UPLOAD_COMPLETED =
                'recording-upload-completed';
+export const DAILY_EVENT_RECORDING_DATA = 'recording-data';
 export const DAILY_EVENT_APP_MSG = 'app-message';
 export const DAILY_EVENT_INPUT_EVENT = 'input-event';
 export const DAILY_EVENT_LOCAL_SCREEN_SHARE_STARTED =

--- a/src/module.js
+++ b/src/module.js
@@ -45,6 +45,7 @@ import {
   DAILY_EVENT_FULLSCREEN,
   DAILY_EVENT_EXIT_FULLSCREEN,
   DAILY_EVENT_NETWORK_CONNECTION,
+  DAILY_EVENT_RECORDING_DATA,
 
   // internals
   //
@@ -1156,6 +1157,7 @@ export default class DailyIframe extends EventEmitter {
       case DAILY_EVENT_LOCAL_SCREEN_SHARE_STARTED:
       case DAILY_EVENT_LOCAL_SCREEN_SHARE_STOPPED:
       case DAILY_EVENT_NETWORK_CONNECTION:
+      case DAILY_EVENT_RECORDING_DATA:
         try {
           this.emit(msg.action, msg);
         } catch (e) {


### PR DESCRIPTION
Add a new 'recording-data' event to allow handling of recording byte stream in javascript.

More information here in companion pluot-core pr: https://github.com/daily-co/pluot-core/pull/1387