### PR TITLE
add { mediaStream } option to startScreenShare()

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -762,7 +762,7 @@ export default class DailyIframe extends EventEmitter {
     });
   }
 
-  startScreenShare(captureOptions) {
+  startScreenShare(captureOptions={}) {
     if (captureOptions.mediaStream) {
       this._preloadCache.screenMediaStream = captureOptions.mediaStream;
       captureOptions.mediaStream = DAILY_CUSTOM_TRACK;

--- a/src/module.js
+++ b/src/module.js
@@ -763,6 +763,10 @@ export default class DailyIframe extends EventEmitter {
   }
 
   startScreenShare(captureOptions) {
+    if (captureOptions.mediaStream) {
+      this._preloadCache.screenMediaStream = captureOptions.mediaStream;
+      captureOptions.mediaStream = DAILY_CUSTOM_TRACK;
+    }
     this._sendIframeMsg({ action: DAILY_METHOD_START_SCREENSHARE,
                           captureOptions });
   }


### PR DESCRIPTION
Companion to https://github.com/daily-co/pluot-core/pull/1390

```
callObject.startScreenShare({ mediaStream: stream })
```