### PR TITLE
Fix bug in ReactNativeMessageChannel that prevented callbacks from oc…

### DIFF
--- a/src/shared-with-pluot-core/script-message-channels/ReactNativeMessageChannel.js
+++ b/src/shared-with-pluot-core/script-message-channels/ReactNativeMessageChannel.js
@@ -73,7 +73,6 @@ export default class ReactNativeMessageChannel extends ScriptMessageChannel {
         this._messageCallbacks[callbackStamp].call(thisValue, msg);
         delete this._messageCallbacks[callbackStamp];
       }
-      delete msg.callbackStamp;
       listener.call(thisValue, msg);
     };
     this._wrappedListeners[listener] = wrappedListener;


### PR DESCRIPTION
…curring.

Explanation: 

1. `daily-js` sends a message with a `callbackStamp` to the call machine
2. the call machine receives this message and invokes the offending line, deleting `callbackStamp`
3. the call machine sends the message back to `daily-js`
4. there's no `callbackStamp` present, so the registered callback is never invoked

In `WebMessageChannel`, there is a line that always clears out "internal state" like `callbackStamp` from the received message before invoking its handler (when the message is coming *from* the call machine, and sent *to* `daily-js`). 

This line was here to try to preserve that behavior (erroneously, since it's run on both sides of the communication channel). However, thinking through it, I don't think this kind of cleanup would really serve any purpose: if we ever have a `callbackStamp` set on a received message on the call machine side, we should definitely pass it along to the handler. If we have a `callbackStamp` set on a received message on the `daily-js` side, we *should* also have a registered callback, which will do the appropriate cleanup. If we *don't* have a registered callback, then we're in uncharted/unexpected territory, and it's not necessarily clear that we ought to clear `callbackStamp` before passing the message to its handler.