### PR TITLE
Avoid trying to look up browser information (which will fail) when ru…

### DIFF
--- a/src/shared-with-pluot-core/Environment.js
+++ b/src/shared-with-pluot-core/Environment.js
@@ -5,6 +5,17 @@ export function isReactNative() {
 }
 
 export function browserInfo() {
+  if (isReactNative()) {
+    return {
+      supported: true,
+      mobile: true,
+      name: "React Native",
+      version: null,
+      supportsScreenShare: false,
+      supportsSfu: true,
+    };
+  }
+
   function supportsUnifiedPlanSDP(browser) {
     return browser.satisfies({
       electron: ">=6",


### PR DESCRIPTION
…nning in React Native. This lookup recently became part of the normal `join()` code path as part of this change: https://github.com/daily-co/daily-js/commit/6269ee6be6943c96b0eed6b7d8d0e13dfb064ddf