### PR TITLE
Access the `_iframe` instance variable directly internally, so that t…

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -423,7 +423,7 @@ export default class DailyIframe extends EventEmitter {
         await this.leave();
       }
     } catch (e) {}
-    let iframe = this.iframe();
+    let iframe = this._iframe;
     if (iframe) {
       let parent = iframe.parentElement;
       if (parent) {


### PR DESCRIPTION
…he `iframe()` method can be reserved just for external use, letting us gatekeep it against RN usage via `methodNotSupportedInReactNative()`.