### PR TITLE
fix always loading bundle from cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/daily-js",
-  "version": "0.9.992-beta.1",
+  "version": "0.9.992-beta.3",
   "engines": {
     "node": ">=10.0.0"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,8 +5,12 @@ export function notImplementedError() {
 }
 
 export function callObjectBundleUrl(meetingUrl) {
-  // Use the CDN to get call-machine-object (but use whatever's "local" for dev+staging)
-  if (process.env.NODE_ENV === 'production') {
+  // Use the CDN to get call-machine-object. (But use whatever's
+  // "local" for dev+staging, checking both the build-time NODE_ENV
+  // variable and whether the meetingUrl is foo.daily.co and not, for
+  // example, foo.staging.daily.co)
+  if (process.env.NODE_ENV === 'production' &&
+      meetingUrl && meetingUrl.match(/https:\/\/[^.]+\.daily\.co\//)) {
     if (!browserInfo().supportsSfu) {
       return `https://c.daily.co/static/call-machine-object-nosfu-bundle.js`;
     } else {


### PR DESCRIPTION
It's useful to have staging servers load `call-machine-object-bundle.js` from the origin server. This patch extends the cdn work that @sangelone did to also test whether the current meeting url is not a production meeting url. If it's not, we load the bundle from the origin server rather than the cdn.