### PR TITLE
display-capture permission on iframe

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -310,7 +310,7 @@ export default class DailyIframe extends EventEmitter {
         window.navigator.userAgent.match(/Chrome\/61\./)) {
       iframeEl.allow = 'microphone, camera';
     } else {
-      iframeEl.allow = 'microphone; camera; autoplay';
+      iframeEl.allow = 'microphone; camera; autoplay; display-capture';
     }
     iframeEl.style.visibility = 'hidden';
     parentEl.appendChild(iframeEl);


### PR DESCRIPTION
Add the `display-capture` feature policy to the call iframe. Safari recently started enforcing this for screen sharing.