### PR TITLE
Fix React Native breaking due to `callFrameId` lookup on nonexistent …

### DIFF
--- a/src/call-object-loaders/CallObjectLoader.js
+++ b/src/call-object-loaders/CallObjectLoader.js
@@ -2,13 +2,13 @@ import { notImplementedError } from "../utils";
 
 export default class CallObjectLoader {
   /**
-   * Loads the call machine bundle (if needed), then invokes the callback
+   * Loads the call object bundle (if needed), then invokes the callback
    * function, which takes one boolean argument whose value is true if the
    * load was a no-op.
    * 
-   * No-op loads can happen if the bundle is a "call object" bundle that runs
-   * in the same scope as the caller of this function and so only needs to be
-   * run once ever since its global setup work is done.
+   * No-op loads can happen when leaving a meeting and then later joining one.
+   * Since the call object bundle sets up global state in the same scope as the
+   * app code consuming it, it only needs to be loaded and executed once ever.
    * 
    * @param callback Callback function that takes a wasNoOp argument.
    * @param meetingUrl Meeting URL, used to determine where to load the bundle from.

--- a/src/call-object-loaders/CallObjectLoaderReactNative.js
+++ b/src/call-object-loaders/CallObjectLoaderReactNative.js
@@ -1,8 +1,19 @@
 import CallObjectLoader from "./CallObjectLoader";
 import { callObjectBundleUrl } from "../utils";
 
+function setUpDailyConfig() {
+  // The call object bundle expects a global _dailyConfig to already exist,
+  // to read a callFrameId from. In React Native, there's no so such thing as
+  // other ongoing calls in iframes, so just provide an empty string.
+  if (!window._dailyConfig) {
+    window._dailyConfig = {};
+  }
+  window._dailyConfig.callFrameId = "";
+}
+
 export default class CallObjectLoaderReactNative extends CallObjectLoader {
-  load(meetingUrl, callFrameId, callback) {
+  load(meetingUrl, _, callback) {
+    setUpDailyConfig();
     const url = callObjectBundleUrl(meetingUrl);
     fetch(url)
       .then((res) => {


### PR DESCRIPTION
…`_dailyConfig` object.

Also, update a comment for clarity.