### PR TITLE
Allow "no-op" calls to `load()` in React Native, mirroring the behavi…

### DIFF
--- a/src/call-object-loaders/CallObjectLoaderReactNative.js
+++ b/src/call-object-loaders/CallObjectLoaderReactNative.js
@@ -1,6 +1,8 @@
 import CallObjectLoader from "./CallObjectLoader";
 import { callObjectBundleUrl } from "../utils";
 
+const EMPTY_CALL_FRAME_ID = "";
+
 function setUpDailyConfig() {
   // The call object bundle expects a global _dailyConfig to already exist,
   // to read a callFrameId from. In React Native, there's no so such thing as
@@ -8,12 +10,26 @@ function setUpDailyConfig() {
   if (!window._dailyConfig) {
     window._dailyConfig = {};
   }
-  window._dailyConfig.callFrameId = "";
+  window._dailyConfig.callFrameId = EMPTY_CALL_FRAME_ID;
 }
 
 export default class CallObjectLoaderReactNative extends CallObjectLoader {
+  constructor() {
+    super();
+    this._callObjectScriptLoaded = false;
+  }
   load(meetingUrl, _, callback) {
     setUpDailyConfig();
+
+    // Call object script already loaded once, so no-op.
+    // This happens after leave()ing and join()ing again.
+    if (this._callObjectScriptLoaded) {
+      window._dailyCallObjectSetup(EMPTY_CALL_FRAME_ID);
+      callback(true); // true = "this load() was a no-op"
+      return;
+    }
+
+    // Load the call object
     const url = callObjectBundleUrl(meetingUrl);
     fetch(url)
       .then((res) => {
@@ -23,7 +39,8 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
         eval(code);
       })
       .then(() => {
-        callback(false); // false = "wasn't no-op"
+        this._callObjectScriptLoaded = true;
+        callback(false); // false = "this load() wasn't a no-op"
       })
       .catch((e) => {
         console.error("Failed to load RN call object bundle", e);

--- a/src/call-object-loaders/CallObjectLoaderWeb.js
+++ b/src/call-object-loaders/CallObjectLoaderWeb.js
@@ -14,12 +14,12 @@ export default class CallObjectLoaderWeb extends CallObjectLoader {
     }
     if (this._callObjectScriptLoaded) {
       window._dailyCallObjectSetup(callFrameId);
-      callback(true); // true = "was no-op"
+      callback(true); // true = "this load() was a no-op"
     } else {
       // add a global callFrameId so we can have both iframes and one
       // call object mode calls live at the same time
       if (!window._dailyConfig) {
-        window._dailyConfig = {}
+        window._dailyConfig = {};
       }
       window._dailyConfig.callFrameId = callFrameId;
 
@@ -27,7 +27,7 @@ export default class CallObjectLoaderWeb extends CallObjectLoader {
         script = document.createElement("script");
       script.onload = async () => {
         this._callObjectScriptLoaded = true;
-        callback(false); // false = "wasn't no-op"
+        callback(false); // false = "this load() wasn't a no-op"
       };
       script.src = callObjectBundleUrl(meetingUrl);
       head.appendChild(script);

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -1,3 +1,6 @@
+// This is a work-in-progress and incomplete, and not yet exposed through
+// package.json. Use at your own risk!
+
 // Type definitions for daily-js 0.0.987
 // Project: https://github.com/daily-co/daily-js
 // Definitions by: Paul Kompfner <https://github.com/kompfner>


### PR DESCRIPTION
…or in a browser in the case of `leave()`ing then `join()`ing again without `destroy()`ing the call object in between.

## Tests

- [x] On web (as a baseline to compare this change to)
  - [x] When `destroy()`ing between `join()`s
    - [x] Verify that `load()` never no-ops
    - [x] Verify that call works after all `join()`s
    - [x] Verify that events fire as expected
  - [x] When not `destroy()`ing between `join()`s
    - [x] Verify that `load()` never no-ops
    - [x] Verify that call works after all `join()`s
    - [x] Verify that events fire as expected
- [x] In React Native
  - [x] When `destroy()`ing between `join()`s
    - [x] Verify that `load()` never no-ops
    - [x] Verify that call works after all `join()`s
    - [x] Verify that events fire as expected
  - [x] When not `destroy()`ing between `join()`s
    - [x] Verify that `load()` never no-ops
    - [x] Verify that call works after all `join()`s
    - [x] Verify that events fire as expected