### PR TITLE
Complete TypeScript type declaration coverage of the `daily-js` API

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -923,7 +923,7 @@ export default class DailyIframe extends EventEmitter {
 
   async geo() {
     methodNotSupportedInReactNative();
-    return new Promise(async (resolve, reject) => {
+    return new Promise(async (resolve, _) => {
       try {
         let url = 'https://gs.daily.co/_ks_/x-swsl/:';
         let res = await fetch(url);

--- a/src/module.js
+++ b/src/module.js
@@ -783,7 +783,7 @@ export default class DailyIframe extends EventEmitter {
       let stats = { latest: {} };
       return { stats };
     }
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _) => {
       let k = (msg) => {
         resolve({ stats: msg.stats, ...this._network });
       }

--- a/src/module.js
+++ b/src/module.js
@@ -241,7 +241,6 @@ export default class DailyIframe extends EventEmitter {
   //
 
   static supportedBrowser() {
-    methodNotSupportedInReactNative();
     return browserInfo();
   }
 

--- a/src/module.js
+++ b/src/module.js
@@ -911,7 +911,7 @@ export default class DailyIframe extends EventEmitter {
     if (this._meetingState !== DAILY_STATE_JOINED) {
       return null;
     }
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _) => {
       let k = (msg) => {
         delete msg.action;
         delete msg.callbackStamp;

--- a/src/module.js
+++ b/src/module.js
@@ -825,6 +825,7 @@ export default class DailyIframe extends EventEmitter {
     this.sendMessageToCallMachine({
       action: DAILY_METHOD_SET_SUBSCRIBE_TO_TRACKS_AUTOMATICALLY, enabled
     });
+    return this;
   }
 
   async enumerateDevices(kind) {

--- a/src/module.js
+++ b/src/module.js
@@ -526,7 +526,7 @@ export default class DailyIframe extends EventEmitter {
   }
 
   startCamera(properties={}) {
-    return new Promise(async (resolve, reject) => {
+    return new Promise(async (resolve, _) => {
       let k = (msg) => {
         delete msg.action;
         delete msg.callbackStamp;
@@ -540,7 +540,6 @@ export default class DailyIframe extends EventEmitter {
         properties: makeSafeForPostMessage(this.properties),
       }, k);
     });
-    return this;
   }
 
   cycleCamera() {

--- a/src/module.js
+++ b/src/module.js
@@ -544,7 +544,7 @@ export default class DailyIframe extends EventEmitter {
 
   cycleCamera() {
     methodNotSupportedInReactNative();
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _) => {
       let k = (msg) => {
         resolve({ device: msg.device });
       };
@@ -554,7 +554,7 @@ export default class DailyIframe extends EventEmitter {
 
   cycleMic() {
     methodNotSupportedInReactNative();
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _) => {
       let k = (msg) => {
         resolve({ device: msg.device });
       };

--- a/src/module.js
+++ b/src/module.js
@@ -828,18 +828,18 @@ export default class DailyIframe extends EventEmitter {
     return this;
   }
 
-  async enumerateDevices(kind) {
+  async enumerateDevices() {
     methodNotSupportedInReactNative();
     if (this._callObjectMode) {
       let raw = await navigator.mediaDevices.enumerateDevices();
       return { devices: raw.map((d) => JSON.parse(JSON.stringify(d))) };
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _) => {
       let k = (msg) => {
         resolve({ devices: msg.devices });
       }
-      this.sendMessageToCallMachine({ action: DAILY_METHOD_ENUMERATE_DEVICES, kind }, k);
+      this.sendMessageToCallMachine({ action: DAILY_METHOD_ENUMERATE_DEVICES }, k);
     });    
   }
 

--- a/src/module.js
+++ b/src/module.js
@@ -873,7 +873,7 @@ export default class DailyIframe extends EventEmitter {
 
   detectAllFaces() {
     methodNotSupportedInReactNative();
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _) => {
       let k = (msg) => {
         delete msg.action;
         delete msg.callbackStamp;

--- a/src/module.js
+++ b/src/module.js
@@ -730,7 +730,7 @@ export default class DailyIframe extends EventEmitter {
   }
 
   async leave() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _) => {
       let k = () => {
         if (this._iframe) {
           // resetting the iframe src maybe interferes with sending the

--- a/src/module.js
+++ b/src/module.js
@@ -664,7 +664,7 @@ export default class DailyIframe extends EventEmitter {
     else {
       // iframe
       this._iframe.src = this.assembleMeetingUrl();
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve, _) => {
         this._loadedCallback = () => {
           this._meetingState = DAILY_STATE_LOADED;
           if (this.properties.cssFile || this.properties.cssText) {

--- a/src/module.js
+++ b/src/module.js
@@ -522,6 +522,7 @@ export default class DailyIframe extends EventEmitter {
   setDailyLang(lang) {
     methodNotSupportedInReactNative();
     this.sendMessageToCallMachine({ action: DAILY_METHOD_SET_LANG, lang });
+    return this;
   }
 
   startCamera(properties={}) {

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -13,6 +13,7 @@ export = DailyIframe;
 
 // Declares class methods and properties.
 declare class DailyIframe {
+  static supportedBrowser(): DailyIframe.BrowserInfo;
   static createCallObject(properties?: DailyIframe.FrameProps): DailyIframe;
   join(
     properties?: DailyIframe.FrameProps
@@ -31,7 +32,17 @@ declare class DailyIframe {
 
 // Declares supporting types under the `DailyIframe` namespace.
 declare namespace DailyIframe {
+  type BrowserInfo = {
+    supported: boolean;
+    mobile: boolean;
+    name: string;
+    version: string;
+    supportsScreenShare: boolean;
+    supportsSfu: boolean;
+  };
+
   type FrameProps = object; // TODO: flesh out
+
   type Participant = {
     audio: boolean;
     audioTrack?: any; // TODO: see if there's a way we can use MediaStreamTrack here that works with browser + RN...

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -95,6 +95,7 @@ declare class DailyIframe {
   setNetworkTopology(options: {
     topology: "sfu" | "peer";
   }): Promise<{ workerId?: string; error?: string }>;
+  setPlayNewParticipantSound(sound: boolean | number): void;
   on(
     event: DailyIframe.Event,
     handler: (event?: DailyIframe.EventObject) => void

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -75,6 +75,7 @@ declare class DailyIframe {
   stopScreenShare(): void;
   startRecording(): void;
   stopRecording(): void;
+  getNetworkStats(): Promise<DailyIframe.NetworkStats>;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
@@ -166,6 +167,24 @@ declare namespace DailyIframe {
     maxHeight?: number;
     chromeMediaSourceId?: string;
     mediaStream?: MediaStream;
+  }
+
+  interface NetworkStats {
+    quality: number;
+    stats: {
+      latest: {
+        recvBitsPerSecond: number;
+        sendBitsPerSecond: number;
+        timestamp: number;
+        videoRecvBitsPerSecond: number;
+        videoRecvPacketLoss: number;
+        videoSendBitsPerSecond: number;
+        videoSendPacketLoss: number;
+      };
+      worstVideoRecvPacketLoss: number;
+      worstVideoSendPacketLoss: number;
+    };
+    threshold: "good" | "low" | "very-low";
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -85,6 +85,9 @@ declare class DailyIframe {
   sendAppMessage(data: any, to?: string): DailyIframe;
   addFakeParticipant(details?: { aspectRatio: number }): DailyIframe;
   setShowNamesMode(mode: false | "always" | "never"): DailyIframe;
+  detectAllFaces(): Promise<{
+    faces?: { [id: string]: DailyIframe.FaceInfo[] };
+  }>;
   requestFullscreen(): Promise<void>;
   exitFullscreen(): void;
   room(): Promise<DailyIframe.RoomInfo | null>;
@@ -236,6 +239,18 @@ declare namespace DailyIframe {
   interface EventObject {
     action: string;
     [payloadProp: string]: any;
+  }
+
+  interface FaceInfo {
+    score: number;
+    viewportBox: {
+      width: number;
+      height: number;
+      left: number;
+      top: number;
+      right: number;
+      bottom: number;
+    };
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -87,6 +87,7 @@ declare class DailyIframe {
   setShowNamesMode(mode: false | "always" | "never"): DailyIframe;
   requestFullscreen(): Promise<void>;
   exitFullscreen(): void;
+  room(): Promise<DailyIframe.RoomInfo | null>;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
@@ -199,6 +200,28 @@ declare namespace DailyIframe {
       worstVideoSendPacketLoss: number;
     };
     threshold: "good" | "low" | "very-low";
+  }
+
+  interface RoomInfo {
+    id: string;
+    name: string;
+    config: {
+      nbf?: number;
+      exp?: number;
+      max_participants?: number;
+      enable_chat?: boolean;
+      enable_knocking?: boolean;
+      enable_recording?: string;
+      enable_dialin?: boolean;
+      autojoin?: boolean;
+      meeting_join_hook?: string;
+      eject_at_room_exp?: boolean;
+      eject_after_elapsed?: number;
+      lang?: "" | Language;
+      signaling_impl?: string;
+      geo?: string;
+    };
+    dialInPIN?: string;
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -83,6 +83,7 @@ declare class DailyIframe {
   setSubscribeToTracksAutomatically(enabled: boolean): DailyIframe;
   enumerateDevices(): Promise<{ devices: MediaDeviceInfo[] }>;
   sendAppMessage(data: any, to?: string): DailyIframe;
+  setShowNamesMode(mode: false | "always" | "never"): DailyIframe;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -64,6 +64,8 @@ declare class DailyIframe {
     mic?: {} | null | MediaDeviceInfo;
     speaker?: {} | null | MediaDeviceInfo;
   }>;
+  cycleCamera(): Promise<{ device?: MediaDeviceInfo | null }>;
+  cycleMic(): Promise<{ device?: MediaDeviceInfo | null }>;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -59,11 +59,7 @@ declare class DailyIframe {
   setDailyLang(lang: DailyIframe.Language): DailyIframe;
   startCamera(
     properties?: DailyIframe.FrameProps
-  ): Promise<{
-    camera?: {} | null | MediaDeviceInfo;
-    mic?: {} | null | MediaDeviceInfo;
-    speaker?: {} | null | MediaDeviceInfo;
-  }>;
+  ): Promise<DailyIframe.DeviceInfos>;
   cycleCamera(): Promise<{ device?: MediaDeviceInfo | null }>;
   cycleMic(): Promise<{ device?: MediaDeviceInfo | null }>;
   setInputDevices(devices: {
@@ -73,6 +69,7 @@ declare class DailyIframe {
     videoSource?: MediaStreamTrack;
   }): DailyIframe;
   setOutputDevice(audioDevice: { id?: string }): DailyIframe;
+  getInputDevices(): Promise<DailyIframe.DeviceInfos>;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
@@ -139,6 +136,12 @@ declare namespace DailyIframe {
     top: number;
     video_width: number;
     video_height: number;
+  }
+
+  interface DeviceInfos {
+    camera: {} | MediaDeviceInfo;
+    mic: {} | MediaDeviceInfo;
+    speaker: {} | MediaDeviceInfo;
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -52,6 +52,10 @@ declare class DailyIframe {
   localVideo(): boolean;
   setLocalAudio(enabled: boolean): DailyIframe;
   setLocalVideo(enabled: boolean): DailyIframe;
+  setBandwidth(bw: {
+    kbs?: number | "NO_CAP" | null;
+    trackConstraints?: MediaTrackConstraints;
+  }): DailyIframe;
   startCamera(properties?: DailyIframe.FrameProps): Promise<any>; // TODO: flesh out return type
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -88,9 +88,18 @@ declare class DailyIframe {
   requestFullscreen(): Promise<void>;
   exitFullscreen(): void;
   room(): Promise<DailyIframe.RoomInfo | null>;
-  on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
-  once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
-  off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
+  on(
+    event: DailyIframe.Event,
+    handler: (event?: DailyIframe.EventObject) => void
+  ): DailyIframe;
+  once(
+    event: DailyIframe.Event,
+    handler: (event?: DailyIframe.EventObject) => void
+  ): DailyIframe;
+  off(
+    event: DailyIframe.Event,
+    handler: (event?: DailyIframe.EventObject) => void
+  ): DailyIframe;
 }
 
 // Declares supporting types under the `DailyIframe` namespace.
@@ -222,6 +231,11 @@ declare namespace DailyIframe {
       geo?: string;
     };
     dialInPIN?: string;
+  }
+
+  interface EventObject {
+    action: string;
+    [payloadProp: string]: any;
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -27,6 +27,7 @@ declare class DailyIframe {
   static createTransparentFrame(
     properties?: DailyIframe.FrameProps
   ): DailyIframe;
+  iframe(): HTMLIFrameElement | null;
   join(
     properties?: DailyIframe.FrameProps
   ): Promise<DailyIframe.Participant[] | void>;

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -91,6 +91,7 @@ declare class DailyIframe {
   requestFullscreen(): Promise<void>;
   exitFullscreen(): void;
   room(): Promise<DailyIframe.RoomInfo | null>;
+  geo(): Promise<{ current: string }>;
   on(
     event: DailyIframe.Event,
     handler: (event?: DailyIframe.EventObject) => void

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -13,6 +13,7 @@ export = DailyIframe;
 
 // Declares class methods and properties.
 declare class DailyIframe {
+  // Static methods
   static supportedBrowser(): DailyIframe.BrowserInfo;
   static createCallObject(properties?: DailyIframe.FrameProps): DailyIframe;
   static wrap(
@@ -27,6 +28,8 @@ declare class DailyIframe {
   static createTransparentFrame(
     properties?: DailyIframe.FrameProps
   ): DailyIframe;
+
+  // Instance methods
   iframe(): HTMLIFrameElement | null;
   join(
     properties?: DailyIframe.FrameProps
@@ -45,25 +48,25 @@ declare class DailyIframe {
 
 // Declares supporting types under the `DailyIframe` namespace.
 declare namespace DailyIframe {
-  type BrowserInfo = {
+  interface BrowserInfo {
     supported: boolean;
     mobile: boolean;
     name: string;
     version: string;
     supportsScreenShare: boolean;
     supportsSfu: boolean;
-  };
+  }
 
   type FrameProps = object; // TODO: flesh out
 
-  type Participant = {
+  interface Participant {
     audio: boolean;
-    audioTrack?: any; // TODO: see if there's a way we can use MediaStreamTrack here that works with browser + RN...
+    audioTrack?: MediaStreamTrack;
     video: boolean;
-    videoTrack?: any;
+    videoTrack?: MediaStreamTrack;
     screen: boolean;
-    screenVideoTrack?: any;
-  }; // TODO: flesh out
+    screenVideoTrack?: MediaStreamTrack;
+  }
 
   type MeetingState =
     | "new"

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -56,6 +56,7 @@ declare class DailyIframe {
     kbs?: number | "NO_CAP" | null;
     trackConstraints?: MediaTrackConstraints;
   }): DailyIframe;
+  setDailyLang(lang: DailyIframe.Language): DailyIframe;
   startCamera(properties?: DailyIframe.FrameProps): Promise<any>; // TODO: flesh out return type
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
@@ -163,4 +164,6 @@ declare namespace DailyIframe {
     | "fullscreen"
     | "exited-fullscreen"
     | "error";
+
+  type Language = "de" | "en" | "fi" | "fr" | "nl" | "pt";
 }

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -37,7 +37,10 @@ declare class DailyIframe {
   leave(): Promise<void>;
   destroy(): Promise<void>;
   meetingState(): DailyIframe.MeetingState;
-  participants(): { [id: string]: DailyIframe.Participant };
+  participants(): {
+    local: DailyIframe.Participant;
+    [id: string]: DailyIframe.Participant;
+  };
   setLocalAudio(enabled: boolean): DailyIframe;
   setLocalVideo(enabled: boolean): DailyIframe;
   startCamera(properties?: DailyIframe.FrameProps): Promise<any>; // TODO: flesh out return type
@@ -60,12 +63,35 @@ declare namespace DailyIframe {
   type FrameProps = object; // TODO: flesh out
 
   interface Participant {
+    // audio/video info
     audio: boolean;
     audioTrack?: MediaStreamTrack;
     video: boolean;
     videoTrack?: MediaStreamTrack;
     screen: boolean;
     screenVideoTrack?: MediaStreamTrack;
+
+    // user/session info
+    user_id: string;
+    user_name: string;
+    session_id: string;
+    joined_at: Date;
+    will_eject_at: Date;
+    local: boolean;
+    owner: boolean;
+
+    // video element info (iframe-based calls using standard UI only)
+    cam_info: {} | VideoElementInfo;
+    screen_info: {} | VideoElementInfo;
+  }
+
+  interface VideoElementInfo {
+    height: number;
+    left: number;
+    top: number;
+    video_height: number;
+    video_width: number;
+    width: number;
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -285,6 +285,7 @@ declare namespace DailyIframe {
     | "recording-stats"
     | "recording-error"
     | "recording-upload-completed"
+    | "recording-data"
     | "app-message"
     | "input-event"
     | "local-screen-share-started"

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -87,7 +87,18 @@ declare namespace DailyIframe {
     supportsSfu: boolean;
   }
 
-  type FrameProps = object; // TODO: flesh out
+  interface FrameProps {
+    url?: string;
+    token?: string;
+    lang?: Language;
+    showLeaveButton?: boolean;
+    showFullscreenButton?: boolean;
+    iframeStyle?: object;
+    customLayout?: boolean;
+    cssFile?: string;
+    cssText?: string;
+    dailyConfig?: object;
+  }
 
   interface Participant {
     // audio/video info

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -77,6 +77,8 @@ declare class DailyIframe {
   stopRecording(): void;
   getNetworkStats(): Promise<DailyIframe.NetworkStats>;
   getActiveSpeaker(): { peerId?: string };
+  setActiveSpeakerMode(enabled: boolean): DailyIframe;
+  activeSpeakerMode(): boolean;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -24,6 +24,9 @@ declare class DailyIframe {
     properties?: DailyIframe.FrameProps
   ): DailyIframe;
   static createFrame(properties?: DailyIframe.FrameProps): DailyIframe;
+  static createTransparentFrame(
+    properties?: DailyIframe.FrameProps
+  ): DailyIframe;
   join(
     properties?: DailyIframe.FrameProps
   ): Promise<DailyIframe.Participant[] | void>;

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -71,6 +71,8 @@ declare class DailyIframe {
   setOutputDevice(audioDevice: { id?: string }): DailyIframe;
   getInputDevices(): Promise<DailyIframe.DeviceInfos>;
   load(properties: DailyIframe.FrameProps): Promise<void>;
+  startScreenShare(captureOptions?: DailyIframe.ScreenCaptureOptions): void;
+  stopScreenShare(): void;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
@@ -154,6 +156,14 @@ declare namespace DailyIframe {
     camera: {} | MediaDeviceInfo;
     mic: {} | MediaDeviceInfo;
     speaker: {} | MediaDeviceInfo;
+  }
+
+  interface ScreenCaptureOptions {
+    audio?: boolean;
+    maxWidth?: number;
+    maxHeight?: number;
+    chromeMediaSourceId?: string;
+    mediaStream?: MediaStream;
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -19,6 +19,11 @@ declare class DailyIframe {
     iframe: HTMLIFrameElement,
     properties?: DailyIframe.FrameProps
   ): DailyIframe;
+  static createFrame(
+    parentElement: HTMLElement,
+    properties?: DailyIframe.FrameProps
+  ): DailyIframe;
+  static createFrame(properties?: DailyIframe.FrameProps): DailyIframe;
   join(
     properties?: DailyIframe.FrameProps
   ): Promise<DailyIframe.Participant[] | void>;

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -41,6 +41,13 @@ declare class DailyIframe {
     local: DailyIframe.Participant;
     [id: string]: DailyIframe.Participant;
   };
+  updateParticipant(
+    sessionId: string,
+    updates: DailyIframe.ParticipantUpdates
+  ): DailyIframe;
+  updateParticipants(updates: {
+    [sessionId: string]: DailyIframe.ParticipantUpdates;
+  }): DailyIframe;
   setLocalAudio(enabled: boolean): DailyIframe;
   setLocalVideo(enabled: boolean): DailyIframe;
   startCamera(properties?: DailyIframe.FrameProps): Promise<any>; // TODO: flesh out return type
@@ -85,13 +92,31 @@ declare namespace DailyIframe {
     screen_info: {} | VideoElementInfo;
   }
 
+  interface ParticipantUpdates {
+    setAudio?: boolean;
+    setVideo?: boolean;
+    eject?: true;
+    styles?: ParticipantCss;
+  }
+
+  interface ParticipantCss {
+    cam?: ParticipantStreamCss;
+    screen?: ParticipantStreamCss;
+  }
+
+  interface ParticipantStreamCss {
+    div?: object;
+    overlay?: object;
+    video?: object;
+  }
+
   interface VideoElementInfo {
+    width: number;
     height: number;
     left: number;
     top: number;
-    video_height: number;
     video_width: number;
-    width: number;
+    video_height: number;
   }
 
   type MeetingState =

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -72,6 +72,7 @@ declare class DailyIframe {
     videoDeviceId?: string;
     videoSource?: MediaStreamTrack;
   }): DailyIframe;
+  setOutputDevice(audioDevice: { id?: string }): DailyIframe;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -57,7 +57,13 @@ declare class DailyIframe {
     trackConstraints?: MediaTrackConstraints;
   }): DailyIframe;
   setDailyLang(lang: DailyIframe.Language): DailyIframe;
-  startCamera(properties?: DailyIframe.FrameProps): Promise<any>; // TODO: flesh out return type
+  startCamera(
+    properties?: DailyIframe.FrameProps
+  ): Promise<{
+    camera?: {} | null | MediaDeviceInfo;
+    mic?: {} | null | MediaDeviceInfo;
+    speaker?: {} | null | MediaDeviceInfo;
+  }>;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -70,6 +70,7 @@ declare class DailyIframe {
   }): DailyIframe;
   setOutputDevice(audioDevice: { id?: string }): DailyIframe;
   getInputDevices(): Promise<DailyIframe.DeviceInfos>;
+  load(properties: DailyIframe.FrameProps): Promise<void>;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -83,6 +83,7 @@ declare class DailyIframe {
   setSubscribeToTracksAutomatically(enabled: boolean): DailyIframe;
   enumerateDevices(): Promise<{ devices: MediaDeviceInfo[] }>;
   sendAppMessage(data: any, to?: string): DailyIframe;
+  addFakeParticipant(details?: { aspectRatio: number }): DailyIframe;
   setShowNamesMode(mode: false | "always" | "never"): DailyIframe;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -82,6 +82,7 @@ declare class DailyIframe {
   subscribeToTracksAutomatically(): boolean;
   setSubscribeToTracksAutomatically(enabled: boolean): DailyIframe;
   enumerateDevices(): Promise<{ devices: MediaDeviceInfo[] }>;
+  sendAppMessage(data: any, to?: string): DailyIframe;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -76,6 +76,7 @@ declare class DailyIframe {
   startRecording(): void;
   stopRecording(): void;
   getNetworkStats(): Promise<DailyIframe.NetworkStats>;
+  getActiveSpeaker(): { peerId?: string };
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -15,6 +15,10 @@ export = DailyIframe;
 declare class DailyIframe {
   static supportedBrowser(): DailyIframe.BrowserInfo;
   static createCallObject(properties?: DailyIframe.FrameProps): DailyIframe;
+  static wrap(
+    iframe: HTMLIFrameElement,
+    properties?: DailyIframe.FrameProps
+  ): DailyIframe;
   join(
     properties?: DailyIframe.FrameProps
   ): Promise<DailyIframe.Participant[] | void>;

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -92,6 +92,9 @@ declare class DailyIframe {
   exitFullscreen(): void;
   room(): Promise<DailyIframe.RoomInfo | null>;
   geo(): Promise<{ current: string }>;
+  setNetworkTopology(options: {
+    topology: "sfu" | "peer";
+  }): Promise<{ workerId?: string; error?: string }>;
   on(
     event: DailyIframe.Event,
     handler: (event?: DailyIframe.EventObject) => void

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -109,6 +109,8 @@ declare namespace DailyIframe {
     cssText?: string;
     dailyConfig?: object;
     subscribeToTracksAutomatically?: boolean;
+    videoSource?: string | MediaStreamTrack;
+    audioSource?: string | MediaStreamTrack;
   }
 
   interface Participant {

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -79,6 +79,8 @@ declare class DailyIframe {
   getActiveSpeaker(): { peerId?: string };
   setActiveSpeakerMode(enabled: boolean): DailyIframe;
   activeSpeakerMode(): boolean;
+  subscribeToTracksAutomatically(): boolean;
+  setSubscribeToTracksAutomatically(enabled: boolean): DailyIframe;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
@@ -106,6 +108,7 @@ declare namespace DailyIframe {
     cssFile?: string;
     cssText?: string;
     dailyConfig?: object;
+    subscribeToTracksAutomatically?: boolean;
   }
 
   interface Participant {

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -48,6 +48,8 @@ declare class DailyIframe {
   updateParticipants(updates: {
     [sessionId: string]: DailyIframe.ParticipantUpdates;
   }): DailyIframe;
+  localAudio(): boolean;
+  localVideo(): boolean;
   setLocalAudio(enabled: boolean): DailyIframe;
   setLocalVideo(enabled: boolean): DailyIframe;
   startCamera(properties?: DailyIframe.FrameProps): Promise<any>; // TODO: flesh out return type

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -81,6 +81,7 @@ declare class DailyIframe {
   activeSpeakerMode(): boolean;
   subscribeToTracksAutomatically(): boolean;
   setSubscribeToTracksAutomatically(enabled: boolean): DailyIframe;
+  enumerateDevices(): Promise<{ devices: MediaDeviceInfo[] }>;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -66,6 +66,12 @@ declare class DailyIframe {
   }>;
   cycleCamera(): Promise<{ device?: MediaDeviceInfo | null }>;
   cycleMic(): Promise<{ device?: MediaDeviceInfo | null }>;
+  setInputDevices(devices: {
+    audioDeviceId?: string;
+    audioSource?: MediaStreamTrack;
+    videoDeviceId?: string;
+    videoSource?: MediaStreamTrack;
+  }): DailyIframe;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -73,6 +73,8 @@ declare class DailyIframe {
   load(properties: DailyIframe.FrameProps): Promise<void>;
   startScreenShare(captureOptions?: DailyIframe.ScreenCaptureOptions): void;
   stopScreenShare(): void;
+  startRecording(): void;
+  stopRecording(): void;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -85,6 +85,8 @@ declare class DailyIframe {
   sendAppMessage(data: any, to?: string): DailyIframe;
   addFakeParticipant(details?: { aspectRatio: number }): DailyIframe;
   setShowNamesMode(mode: false | "always" | "never"): DailyIframe;
+  requestFullscreen(): Promise<void>;
+  exitFullscreen(): void;
   on(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   once(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler
   off(event: DailyIframe.Event, handler: (event?: any) => void): DailyIframe; // TODO: flesh out handler


### PR DESCRIPTION
## Methodology

For each method in our API:
* Added a rough type declaration in `wip-index.d.ts`
* Honed it using our own documentation (if available) and Tandem's type declaration (if available)
* Further adjusted it based on careful inspection of our code
* Tested the declaration in VS Code by tweaking the React demo app to invoke the method in question (yup, VS Code lets you test TypeScript type checking in regular js files!)
* Ran the React demo app with the tweaks to verify that all the inputs and outputs were accurately captured by the declaration

## What this PR doesn't do

Doesn't yet update `package.json` to publish the TypeScript file.

Also, I'm not sure yet whether it's good practice to embed all the types under the `DailyIframe` namespace. I wanted to first get all the types right in one PR—refactoring later should be relatively easy.