### PR TITLE
Make type declarations truly work for both RN and browser environments, and refactor them for snazziness

### DIFF
--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -5,6 +5,16 @@
 // Project: https://github.com/daily-co/daily-js
 // Definitions by: Paul Kompfner <https://github.com/kompfner>
 
+/**
+ * --- BROWSER-SPECIFIC SECTION ---
+ */
+
+/// <reference lib="dom" />
+
+/**
+ * --- SECTION DUPLICATED WITH REACT-NATIVE-DAILY-JS ---
+ */
+
 // Declares that global variable `DailyIframe` is provided outside a module loader environment.
 export as namespace DailyIframe;
 

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -15,9 +15,9 @@
  * --- SECTION DUPLICATED WITH REACT-NATIVE-DAILY-JS ---
  */
 
-export type Language = "de" | "en" | "fi" | "fr" | "nl" | "pt";
+export type DailyLanguage = "de" | "en" | "fi" | "fr" | "nl" | "pt";
 
-export type Event =
+export type DailyEvent =
   | "loading"
   | "loaded"
   | "started-camera"
@@ -48,7 +48,7 @@ export type Event =
   | "exited-fullscreen"
   | "error";
 
-export type MeetingState =
+export type DailyMeetingState =
   | "new"
   | "loading"
   | "loaded"
@@ -57,7 +57,7 @@ export type MeetingState =
   | "left-meeting"
   | "error";
 
-export interface BrowserInfo {
+export interface DailyBrowserInfo {
   supported: boolean;
   mobile: boolean;
   name: string;
@@ -66,10 +66,10 @@ export interface BrowserInfo {
   supportsSfu: boolean;
 }
 
-export interface FrameProps {
+export interface DailyCallOptions {
   url?: string;
   token?: string;
-  lang?: Language;
+  lang?: DailyLanguage;
   showLeaveButton?: boolean;
   showFullscreenButton?: boolean;
   iframeStyle?: object;
@@ -82,7 +82,7 @@ export interface FrameProps {
   audioSource?: string | MediaStreamTrack;
 }
 
-export interface Participant {
+export interface DailyParticipant {
   // audio/video info
   audio: boolean;
   audioTrack?: MediaStreamTrack;
@@ -101,29 +101,29 @@ export interface Participant {
   owner: boolean;
 
   // video element info (iframe-based calls using standard UI only)
-  cam_info: {} | VideoElementInfo;
-  screen_info: {} | VideoElementInfo;
+  cam_info: {} | DailyVideoElementInfo;
+  screen_info: {} | DailyVideoElementInfo;
 }
 
-export interface ParticipantUpdates {
+export interface DailyParticipantUpdateOptions {
   setAudio?: boolean;
   setVideo?: boolean;
   eject?: true;
-  styles?: ParticipantCss;
+  styles?: DailyParticipantCss;
 }
 
-export interface ParticipantCss {
-  cam?: ParticipantStreamCss;
-  screen?: ParticipantStreamCss;
+export interface DailyParticipantCss {
+  cam?: DailyParticipantStreamCss;
+  screen?: DailyParticipantStreamCss;
 }
 
-export interface ParticipantStreamCss {
+export interface DailyParticipantStreamCss {
   div?: object;
   overlay?: object;
   video?: object;
 }
 
-export interface VideoElementInfo {
+export interface DailyVideoElementInfo {
   width: number;
   height: number;
   left: number;
@@ -132,13 +132,13 @@ export interface VideoElementInfo {
   video_height: number;
 }
 
-export interface DeviceInfos {
+export interface DailyDeviceInfos {
   camera: {} | MediaDeviceInfo;
   mic: {} | MediaDeviceInfo;
   speaker: {} | MediaDeviceInfo;
 }
 
-export interface ScreenCaptureOptions {
+export interface DailyScreenCaptureOptions {
   audio?: boolean;
   maxWidth?: number;
   maxHeight?: number;
@@ -146,7 +146,7 @@ export interface ScreenCaptureOptions {
   mediaStream?: MediaStream;
 }
 
-export interface NetworkStats {
+export interface DailyNetworkStats {
   quality: number;
   stats: {
     latest: {
@@ -164,7 +164,7 @@ export interface NetworkStats {
   threshold: "good" | "low" | "very-low";
 }
 
-export interface RoomInfo {
+export interface DailyRoomInfo {
   id: string;
   name: string;
   config: {
@@ -179,19 +179,19 @@ export interface RoomInfo {
     meeting_join_hook?: string;
     eject_at_room_exp?: boolean;
     eject_after_elapsed?: number;
-    lang?: "" | Language;
+    lang?: "" | DailyLanguage;
     signaling_impl?: string;
     geo?: string;
   };
   dialInPIN?: string;
 }
 
-export interface EventObject {
+export interface DailyEventObject {
   action: string;
   [payloadProp: string]: any;
 }
 
-export interface FaceInfo {
+export interface DailyFaceInfo {
   score: number;
   viewportBox: {
     width: number;
@@ -204,30 +204,36 @@ export interface FaceInfo {
 }
 
 export interface DailyCallFactory {
-  createCallObject(properties?: FrameProps): DailyCall;
-  wrap(iframe: HTMLIFrameElement, properties?: FrameProps): DailyCall;
-  createFrame(parentElement: HTMLElement, properties?: FrameProps): DailyCall;
-  createFrame(properties?: FrameProps): DailyCall;
-  createTransparentFrame(properties?: FrameProps): DailyCall;
+  createCallObject(properties?: DailyCallOptions): DailyCall;
+  wrap(iframe: HTMLIFrameElement, properties?: DailyCallOptions): DailyCall;
+  createFrame(
+    parentElement: HTMLElement,
+    properties?: DailyCallOptions
+  ): DailyCall;
+  createFrame(properties?: DailyCallOptions): DailyCall;
+  createTransparentFrame(properties?: DailyCallOptions): DailyCall;
 }
 
 export interface DailyCallStaticUtils {
-  supportedBrowser(): BrowserInfo;
+  supportedBrowser(): DailyBrowserInfo;
 }
 
 export interface DailyCall {
   iframe(): HTMLIFrameElement | null;
-  join(properties?: FrameProps): Promise<Participant[] | void>;
+  join(properties?: DailyCallOptions): Promise<DailyParticipant[] | void>;
   leave(): Promise<void>;
   destroy(): Promise<void>;
-  meetingState(): MeetingState;
+  meetingState(): DailyMeetingState;
   participants(): {
-    local: Participant;
-    [id: string]: Participant;
+    local: DailyParticipant;
+    [id: string]: DailyParticipant;
   };
-  updateParticipant(sessionId: string, updates: ParticipantUpdates): DailyCall;
+  updateParticipant(
+    sessionId: string,
+    updates: DailyParticipantUpdateOptions
+  ): DailyCall;
   updateParticipants(updates: {
-    [sessionId: string]: ParticipantUpdates;
+    [sessionId: string]: DailyParticipantUpdateOptions;
   }): DailyCall;
   localAudio(): boolean;
   localVideo(): boolean;
@@ -237,8 +243,8 @@ export interface DailyCall {
     kbs?: number | "NO_CAP" | null;
     trackConstraints?: MediaTrackConstraints;
   }): DailyCall;
-  setDailyLang(lang: Language): DailyCall;
-  startCamera(properties?: FrameProps): Promise<DeviceInfos>;
+  setDailyLang(lang: DailyLanguage): DailyCall;
+  startCamera(properties?: DailyCallOptions): Promise<DailyDeviceInfos>;
   cycleCamera(): Promise<{ device?: MediaDeviceInfo | null }>;
   cycleMic(): Promise<{ device?: MediaDeviceInfo | null }>;
   setInputDevices(devices: {
@@ -248,13 +254,13 @@ export interface DailyCall {
     videoSource?: MediaStreamTrack;
   }): DailyCall;
   setOutputDevice(audioDevice: { id?: string }): DailyCall;
-  getInputDevices(): Promise<DeviceInfos>;
-  load(properties: FrameProps): Promise<void>;
-  startScreenShare(captureOptions?: ScreenCaptureOptions): void;
+  getInputDevices(): Promise<DailyDeviceInfos>;
+  load(properties: DailyCallOptions): Promise<void>;
+  startScreenShare(captureOptions?: DailyScreenCaptureOptions): void;
   stopScreenShare(): void;
   startRecording(): void;
   stopRecording(): void;
-  getNetworkStats(): Promise<NetworkStats>;
+  getNetworkStats(): Promise<DailyNetworkStats>;
   getActiveSpeaker(): { peerId?: string };
   setActiveSpeakerMode(enabled: boolean): DailyCall;
   activeSpeakerMode(): boolean;
@@ -265,19 +271,25 @@ export interface DailyCall {
   addFakeParticipant(details?: { aspectRatio: number }): DailyCall;
   setShowNamesMode(mode: false | "always" | "never"): DailyCall;
   detectAllFaces(): Promise<{
-    faces?: { [id: string]: FaceInfo[] };
+    faces?: { [id: string]: DailyFaceInfo[] };
   }>;
   requestFullscreen(): Promise<void>;
   exitFullscreen(): void;
-  room(): Promise<RoomInfo | null>;
+  room(): Promise<DailyRoomInfo | null>;
   geo(): Promise<{ current: string }>;
   setNetworkTopology(options: {
     topology: "sfu" | "peer";
   }): Promise<{ workerId?: string; error?: string }>;
   setPlayNewParticipantSound(sound: boolean | number): void;
-  on(event: Event, handler: (event?: EventObject) => void): DailyCall;
-  once(event: Event, handler: (event?: EventObject) => void): DailyCall;
-  off(event: Event, handler: (event?: EventObject) => void): DailyCall;
+  on(event: DailyEvent, handler: (event?: DailyEventObject) => void): DailyCall;
+  once(
+    event: DailyEvent,
+    handler: (event?: DailyEventObject) => void
+  ): DailyCall;
+  off(
+    event: DailyEvent,
+    handler: (event?: DailyEventObject) => void
+  ): DailyCall;
 }
 
 declare const DailyIframe: DailyCallFactory & DailyCallStaticUtils;

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -15,61 +15,230 @@
  * --- SECTION DUPLICATED WITH REACT-NATIVE-DAILY-JS ---
  */
 
-// Declares that global variable `DailyIframe` is provided outside a module loader environment.
-export as namespace DailyIframe;
+export type Language = "de" | "en" | "fi" | "fr" | "nl" | "pt";
 
-// Declares that the class DailyIframe is the thing exported from the module.
-export = DailyIframe;
+export type Event =
+  | "loading"
+  | "loaded"
+  | "started-camera"
+  | "camera-error"
+  | "joining-meeting"
+  | "joined-meeting"
+  | "left-meeting"
+  | "participant-joined"
+  | "participant-updated"
+  | "participant-left"
+  | "track-started"
+  | "track-stopped"
+  | "recording-started"
+  | "recording-stopped"
+  | "recording-stats"
+  | "recording-error"
+  | "recording-upload-completed"
+  | "recording-data"
+  | "app-message"
+  | "input-event"
+  | "local-screen-share-started"
+  | "local-screen-share-stopped"
+  | "active-speaker-change"
+  | "active-speaker-mode-change"
+  | "network-quality-change"
+  | "network-connection"
+  | "fullscreen"
+  | "exited-fullscreen"
+  | "error";
 
-// Declares class methods and properties.
-declare class DailyIframe {
-  // Static methods
-  static supportedBrowser(): DailyIframe.BrowserInfo;
-  static createCallObject(properties?: DailyIframe.FrameProps): DailyIframe;
-  static wrap(
-    iframe: HTMLIFrameElement,
-    properties?: DailyIframe.FrameProps
-  ): DailyIframe;
-  static createFrame(
-    parentElement: HTMLElement,
-    properties?: DailyIframe.FrameProps
-  ): DailyIframe;
-  static createFrame(properties?: DailyIframe.FrameProps): DailyIframe;
-  static createTransparentFrame(
-    properties?: DailyIframe.FrameProps
-  ): DailyIframe;
+export type MeetingState =
+  | "new"
+  | "loading"
+  | "loaded"
+  | "joining-meeting"
+  | "joined-meeting"
+  | "left-meeting"
+  | "error";
 
-  // Instance methods
+export interface BrowserInfo {
+  supported: boolean;
+  mobile: boolean;
+  name: string;
+  version: string;
+  supportsScreenShare: boolean;
+  supportsSfu: boolean;
+}
+
+export interface FrameProps {
+  url?: string;
+  token?: string;
+  lang?: Language;
+  showLeaveButton?: boolean;
+  showFullscreenButton?: boolean;
+  iframeStyle?: object;
+  customLayout?: boolean;
+  cssFile?: string;
+  cssText?: string;
+  dailyConfig?: object;
+  subscribeToTracksAutomatically?: boolean;
+  videoSource?: string | MediaStreamTrack;
+  audioSource?: string | MediaStreamTrack;
+}
+
+export interface Participant {
+  // audio/video info
+  audio: boolean;
+  audioTrack?: MediaStreamTrack;
+  video: boolean;
+  videoTrack?: MediaStreamTrack;
+  screen: boolean;
+  screenVideoTrack?: MediaStreamTrack;
+
+  // user/session info
+  user_id: string;
+  user_name: string;
+  session_id: string;
+  joined_at: Date;
+  will_eject_at: Date;
+  local: boolean;
+  owner: boolean;
+
+  // video element info (iframe-based calls using standard UI only)
+  cam_info: {} | VideoElementInfo;
+  screen_info: {} | VideoElementInfo;
+}
+
+export interface ParticipantUpdates {
+  setAudio?: boolean;
+  setVideo?: boolean;
+  eject?: true;
+  styles?: ParticipantCss;
+}
+
+export interface ParticipantCss {
+  cam?: ParticipantStreamCss;
+  screen?: ParticipantStreamCss;
+}
+
+export interface ParticipantStreamCss {
+  div?: object;
+  overlay?: object;
+  video?: object;
+}
+
+export interface VideoElementInfo {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+  video_width: number;
+  video_height: number;
+}
+
+export interface DeviceInfos {
+  camera: {} | MediaDeviceInfo;
+  mic: {} | MediaDeviceInfo;
+  speaker: {} | MediaDeviceInfo;
+}
+
+export interface ScreenCaptureOptions {
+  audio?: boolean;
+  maxWidth?: number;
+  maxHeight?: number;
+  chromeMediaSourceId?: string;
+  mediaStream?: MediaStream;
+}
+
+export interface NetworkStats {
+  quality: number;
+  stats: {
+    latest: {
+      recvBitsPerSecond: number;
+      sendBitsPerSecond: number;
+      timestamp: number;
+      videoRecvBitsPerSecond: number;
+      videoRecvPacketLoss: number;
+      videoSendBitsPerSecond: number;
+      videoSendPacketLoss: number;
+    };
+    worstVideoRecvPacketLoss: number;
+    worstVideoSendPacketLoss: number;
+  };
+  threshold: "good" | "low" | "very-low";
+}
+
+export interface RoomInfo {
+  id: string;
+  name: string;
+  config: {
+    nbf?: number;
+    exp?: number;
+    max_participants?: number;
+    enable_chat?: boolean;
+    enable_knocking?: boolean;
+    enable_recording?: string;
+    enable_dialin?: boolean;
+    autojoin?: boolean;
+    meeting_join_hook?: string;
+    eject_at_room_exp?: boolean;
+    eject_after_elapsed?: number;
+    lang?: "" | Language;
+    signaling_impl?: string;
+    geo?: string;
+  };
+  dialInPIN?: string;
+}
+
+export interface EventObject {
+  action: string;
+  [payloadProp: string]: any;
+}
+
+export interface FaceInfo {
+  score: number;
+  viewportBox: {
+    width: number;
+    height: number;
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+  };
+}
+
+export interface DailyCallFactory {
+  createCallObject(properties?: FrameProps): DailyCall;
+  wrap(iframe: HTMLIFrameElement, properties?: FrameProps): DailyCall;
+  createFrame(parentElement: HTMLElement, properties?: FrameProps): DailyCall;
+  createFrame(properties?: FrameProps): DailyCall;
+  createTransparentFrame(properties?: FrameProps): DailyCall;
+}
+
+export interface DailyCallStaticUtils {
+  supportedBrowser(): BrowserInfo;
+}
+
+export interface DailyCall {
   iframe(): HTMLIFrameElement | null;
-  join(
-    properties?: DailyIframe.FrameProps
-  ): Promise<DailyIframe.Participant[] | void>;
+  join(properties?: FrameProps): Promise<Participant[] | void>;
   leave(): Promise<void>;
   destroy(): Promise<void>;
-  meetingState(): DailyIframe.MeetingState;
+  meetingState(): MeetingState;
   participants(): {
-    local: DailyIframe.Participant;
-    [id: string]: DailyIframe.Participant;
+    local: Participant;
+    [id: string]: Participant;
   };
-  updateParticipant(
-    sessionId: string,
-    updates: DailyIframe.ParticipantUpdates
-  ): DailyIframe;
+  updateParticipant(sessionId: string, updates: ParticipantUpdates): DailyCall;
   updateParticipants(updates: {
-    [sessionId: string]: DailyIframe.ParticipantUpdates;
-  }): DailyIframe;
+    [sessionId: string]: ParticipantUpdates;
+  }): DailyCall;
   localAudio(): boolean;
   localVideo(): boolean;
-  setLocalAudio(enabled: boolean): DailyIframe;
-  setLocalVideo(enabled: boolean): DailyIframe;
+  setLocalAudio(enabled: boolean): DailyCall;
+  setLocalVideo(enabled: boolean): DailyCall;
   setBandwidth(bw: {
     kbs?: number | "NO_CAP" | null;
     trackConstraints?: MediaTrackConstraints;
-  }): DailyIframe;
-  setDailyLang(lang: DailyIframe.Language): DailyIframe;
-  startCamera(
-    properties?: DailyIframe.FrameProps
-  ): Promise<DailyIframe.DeviceInfos>;
+  }): DailyCall;
+  setDailyLang(lang: Language): DailyCall;
+  startCamera(properties?: FrameProps): Promise<DeviceInfos>;
   cycleCamera(): Promise<{ device?: MediaDeviceInfo | null }>;
   cycleMic(): Promise<{ device?: MediaDeviceInfo | null }>;
   setInputDevices(devices: {
@@ -77,236 +246,40 @@ declare class DailyIframe {
     audioSource?: MediaStreamTrack;
     videoDeviceId?: string;
     videoSource?: MediaStreamTrack;
-  }): DailyIframe;
-  setOutputDevice(audioDevice: { id?: string }): DailyIframe;
-  getInputDevices(): Promise<DailyIframe.DeviceInfos>;
-  load(properties: DailyIframe.FrameProps): Promise<void>;
-  startScreenShare(captureOptions?: DailyIframe.ScreenCaptureOptions): void;
+  }): DailyCall;
+  setOutputDevice(audioDevice: { id?: string }): DailyCall;
+  getInputDevices(): Promise<DeviceInfos>;
+  load(properties: FrameProps): Promise<void>;
+  startScreenShare(captureOptions?: ScreenCaptureOptions): void;
   stopScreenShare(): void;
   startRecording(): void;
   stopRecording(): void;
-  getNetworkStats(): Promise<DailyIframe.NetworkStats>;
+  getNetworkStats(): Promise<NetworkStats>;
   getActiveSpeaker(): { peerId?: string };
-  setActiveSpeakerMode(enabled: boolean): DailyIframe;
+  setActiveSpeakerMode(enabled: boolean): DailyCall;
   activeSpeakerMode(): boolean;
   subscribeToTracksAutomatically(): boolean;
-  setSubscribeToTracksAutomatically(enabled: boolean): DailyIframe;
+  setSubscribeToTracksAutomatically(enabled: boolean): DailyCall;
   enumerateDevices(): Promise<{ devices: MediaDeviceInfo[] }>;
-  sendAppMessage(data: any, to?: string): DailyIframe;
-  addFakeParticipant(details?: { aspectRatio: number }): DailyIframe;
-  setShowNamesMode(mode: false | "always" | "never"): DailyIframe;
+  sendAppMessage(data: any, to?: string): DailyCall;
+  addFakeParticipant(details?: { aspectRatio: number }): DailyCall;
+  setShowNamesMode(mode: false | "always" | "never"): DailyCall;
   detectAllFaces(): Promise<{
-    faces?: { [id: string]: DailyIframe.FaceInfo[] };
+    faces?: { [id: string]: FaceInfo[] };
   }>;
   requestFullscreen(): Promise<void>;
   exitFullscreen(): void;
-  room(): Promise<DailyIframe.RoomInfo | null>;
+  room(): Promise<RoomInfo | null>;
   geo(): Promise<{ current: string }>;
   setNetworkTopology(options: {
     topology: "sfu" | "peer";
   }): Promise<{ workerId?: string; error?: string }>;
   setPlayNewParticipantSound(sound: boolean | number): void;
-  on(
-    event: DailyIframe.Event,
-    handler: (event?: DailyIframe.EventObject) => void
-  ): DailyIframe;
-  once(
-    event: DailyIframe.Event,
-    handler: (event?: DailyIframe.EventObject) => void
-  ): DailyIframe;
-  off(
-    event: DailyIframe.Event,
-    handler: (event?: DailyIframe.EventObject) => void
-  ): DailyIframe;
+  on(event: Event, handler: (event?: EventObject) => void): DailyCall;
+  once(event: Event, handler: (event?: EventObject) => void): DailyCall;
+  off(event: Event, handler: (event?: EventObject) => void): DailyCall;
 }
 
-// Declares supporting types under the `DailyIframe` namespace.
-declare namespace DailyIframe {
-  interface BrowserInfo {
-    supported: boolean;
-    mobile: boolean;
-    name: string;
-    version: string;
-    supportsScreenShare: boolean;
-    supportsSfu: boolean;
-  }
+declare const DailyIframe: DailyCallFactory & DailyCallStaticUtils;
 
-  interface FrameProps {
-    url?: string;
-    token?: string;
-    lang?: Language;
-    showLeaveButton?: boolean;
-    showFullscreenButton?: boolean;
-    iframeStyle?: object;
-    customLayout?: boolean;
-    cssFile?: string;
-    cssText?: string;
-    dailyConfig?: object;
-    subscribeToTracksAutomatically?: boolean;
-    videoSource?: string | MediaStreamTrack;
-    audioSource?: string | MediaStreamTrack;
-  }
-
-  interface Participant {
-    // audio/video info
-    audio: boolean;
-    audioTrack?: MediaStreamTrack;
-    video: boolean;
-    videoTrack?: MediaStreamTrack;
-    screen: boolean;
-    screenVideoTrack?: MediaStreamTrack;
-
-    // user/session info
-    user_id: string;
-    user_name: string;
-    session_id: string;
-    joined_at: Date;
-    will_eject_at: Date;
-    local: boolean;
-    owner: boolean;
-
-    // video element info (iframe-based calls using standard UI only)
-    cam_info: {} | VideoElementInfo;
-    screen_info: {} | VideoElementInfo;
-  }
-
-  interface ParticipantUpdates {
-    setAudio?: boolean;
-    setVideo?: boolean;
-    eject?: true;
-    styles?: ParticipantCss;
-  }
-
-  interface ParticipantCss {
-    cam?: ParticipantStreamCss;
-    screen?: ParticipantStreamCss;
-  }
-
-  interface ParticipantStreamCss {
-    div?: object;
-    overlay?: object;
-    video?: object;
-  }
-
-  interface VideoElementInfo {
-    width: number;
-    height: number;
-    left: number;
-    top: number;
-    video_width: number;
-    video_height: number;
-  }
-
-  interface DeviceInfos {
-    camera: {} | MediaDeviceInfo;
-    mic: {} | MediaDeviceInfo;
-    speaker: {} | MediaDeviceInfo;
-  }
-
-  interface ScreenCaptureOptions {
-    audio?: boolean;
-    maxWidth?: number;
-    maxHeight?: number;
-    chromeMediaSourceId?: string;
-    mediaStream?: MediaStream;
-  }
-
-  interface NetworkStats {
-    quality: number;
-    stats: {
-      latest: {
-        recvBitsPerSecond: number;
-        sendBitsPerSecond: number;
-        timestamp: number;
-        videoRecvBitsPerSecond: number;
-        videoRecvPacketLoss: number;
-        videoSendBitsPerSecond: number;
-        videoSendPacketLoss: number;
-      };
-      worstVideoRecvPacketLoss: number;
-      worstVideoSendPacketLoss: number;
-    };
-    threshold: "good" | "low" | "very-low";
-  }
-
-  interface RoomInfo {
-    id: string;
-    name: string;
-    config: {
-      nbf?: number;
-      exp?: number;
-      max_participants?: number;
-      enable_chat?: boolean;
-      enable_knocking?: boolean;
-      enable_recording?: string;
-      enable_dialin?: boolean;
-      autojoin?: boolean;
-      meeting_join_hook?: string;
-      eject_at_room_exp?: boolean;
-      eject_after_elapsed?: number;
-      lang?: "" | Language;
-      signaling_impl?: string;
-      geo?: string;
-    };
-    dialInPIN?: string;
-  }
-
-  interface EventObject {
-    action: string;
-    [payloadProp: string]: any;
-  }
-
-  interface FaceInfo {
-    score: number;
-    viewportBox: {
-      width: number;
-      height: number;
-      left: number;
-      top: number;
-      right: number;
-      bottom: number;
-    };
-  }
-
-  type MeetingState =
-    | "new"
-    | "loading"
-    | "loaded"
-    | "joining-meeting"
-    | "joined-meeting"
-    | "left-meeting"
-    | "error";
-
-  type Event =
-    | "loading"
-    | "loaded"
-    | "started-camera"
-    | "camera-error"
-    | "joining-meeting"
-    | "joined-meeting"
-    | "left-meeting"
-    | "participant-joined"
-    | "participant-updated"
-    | "participant-left"
-    | "track-started"
-    | "track-stopped"
-    | "recording-started"
-    | "recording-stopped"
-    | "recording-stats"
-    | "recording-error"
-    | "recording-upload-completed"
-    | "recording-data"
-    | "app-message"
-    | "input-event"
-    | "local-screen-share-started"
-    | "local-screen-share-stopped"
-    | "active-speaker-change"
-    | "active-speaker-mode-change"
-    | "network-quality-change"
-    | "network-connection"
-    | "fullscreen"
-    | "exited-fullscreen"
-    | "error";
-
-  type Language = "de" | "en" | "fi" | "fr" | "nl" | "pt";
-}
+export default DailyIframe;

--- a/wip-index.d.ts
+++ b/wip-index.d.ts
@@ -76,11 +76,23 @@ export interface DailyCallOptions {
   customLayout?: boolean;
   cssFile?: string;
   cssText?: string;
-  dailyConfig?: object;
+  dailyConfig?: DailyAdvancedConfig;
   subscribeToTracksAutomatically?: boolean;
   videoSource?: string | MediaStreamTrack;
   audioSource?: string | MediaStreamTrack;
 }
+
+export type DailyAdvancedConfig = {
+  experimentalChromeVideoMuteLightOff: boolean;
+  fastConnect: boolean;
+  preferH264ForCam?: boolean;
+  preferH264ForScreenSharing?: boolean;
+  preferH264?: boolean;
+  disableSimulcast?: boolean;
+  h264Profile?: string;
+  camSimulcastEncodings?: any[];
+  screenSimulcastEncodings?: any[];
+};
 
 export interface DailyParticipant {
   // audio/video info
@@ -290,6 +302,9 @@ export interface DailyCall {
     event: DailyEvent,
     handler: (event?: DailyEventObject) => void
   ): DailyCall;
+  properties: {
+    dailyConfig?: DailyAdvancedConfig;
+  };
 }
 
 declare const DailyIframe: DailyCallFactory & DailyCallStaticUtils;


### PR DESCRIPTION
## Related PR

https://github.com/daily-co/pluot-core/pull/1466

## Discussion

Unfortunately we seem to need a bit of a complicated TypeScript setup to meet the following constraints:

- The `daily-js` package is meant for usage in the browser. As part of its type declarations, it should reference browser versions of WebRTC primitives (like `MediaStreamTrack`).
- The `react-native-daily-js` package is meant for usage in React Native, with the aid of the `react-native-webrtc` library. As part of its type declarations, it should reference `react-native-webrtc` versions of WebRTC primitives.

To do this, the `react-native-daily-js` package must:

- Override the types provided by `daily-js` during its compilation step.
- Expose those overridden types rather than `daily-js`'s original types when consumed by another project.

This turned out to be hairier than I anticipated. It's entirely possible I'm missing some trick, but to make it work for now I had to do the following:

- Create a (mostly) duplicated "override" type declaration in `react-native-daily-js` (see https://github.com/daily-co/daily-js/pull/58/files#diff-169068898bb46fe49f5e5e873fbc8513R9)
- Switch `react-native-daily-js` to use a manually-maintained type declaration rather than automatically-generated one, in order to get it to expose the "override" type declaration (see https://github.com/daily-co/pluot-core/pull/1466/files#diff-182095c943d6e41bf2c28e48a8a8d071R2).

I hope I'm missing some clever TypeScript configuration tricks, and would love to do another pass later to make the maintenance of these files easier without just slapping on more build-time scripting. But for now I'd like to get these in, and am happy to shoulder the burden of keeping the "override" type declarations in sync with the `daily-js` type declarations in the short term.