### PR TITLE
More robust call object bundle loading

### DIFF
--- a/src/call-object-loaders/CallObjectLoader.js
+++ b/src/call-object-loaders/CallObjectLoader.js
@@ -10,10 +10,14 @@ export default class CallObjectLoader {
    * Since the call object bundle sets up global state in the same scope as the
    * app code consuming it, it only needs to be loaded and executed once ever.
    * 
-   * @param callback Callback function that takes a wasNoOp argument.
    * @param meetingUrl Meeting URL, used to determine where to load the bundle from.
+   * @param callFrameId A string identifying this "call frame", to distinguish it 
+   *  from other iframe-based calls for message channel purposes.
+   * @param successCallback Callback function that takes a wasNoOp argument
+   *  (true if call object script was ever loaded once before).
+   * @param failureCallback Callback function that takes an error message.
    */
-  load(meetingUrl, callback) {
+  load(meetingUrl, callFrameId, successCallback, failureCallback) {
     return notImplementedError();
   }
 }

--- a/src/call-object-loaders/CallObjectLoader.js
+++ b/src/call-object-loaders/CallObjectLoader.js
@@ -20,4 +20,12 @@ export default class CallObjectLoader {
   load(meetingUrl, callFrameId, successCallback, failureCallback) {
     return notImplementedError();
   }
+
+  /**
+   * Returns a boolean indicating whether the call object has been loaded and
+   * executed.
+   */
+  get loaded() {
+    return notImplementedError();
+  }
 }

--- a/src/call-object-loaders/CallObjectLoaderReactNative.js
+++ b/src/call-object-loaders/CallObjectLoaderReactNative.js
@@ -34,6 +34,9 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
     const url = callObjectBundleUrl(meetingUrl);
     fetch(url)
       .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Received ${res.status} response`);
+        }
         return res.text();
       })
       .then((code) => {

--- a/src/call-object-loaders/CallObjectLoaderReactNative.js
+++ b/src/call-object-loaders/CallObjectLoaderReactNative.js
@@ -2,6 +2,8 @@ import CallObjectLoader from "./CallObjectLoader";
 import { callObjectBundleUrl } from "../utils";
 
 const EMPTY_CALL_FRAME_ID = "";
+const LOAD_ATTEMPTS = 3;
+const LOAD_ATTEMPT_DELAY_MS = 3000;
 
 function setUpDailyConfig() {
   // The call object bundle expects a global _dailyConfig to already exist,
@@ -20,6 +22,28 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
   }
 
   load(meetingUrl, _, successCallback, failureCallback) {
+    let attemptsRemaining = LOAD_ATTEMPTS;
+    const retryOrFailureCallback = (errorMessage) => {
+      --attemptsRemaining > 0
+        ? setTimeout(
+            () =>
+              this._tryLoad(
+                meetingUrl,
+                successCallback,
+                retryOrFailureCallback
+              ),
+            LOAD_ATTEMPT_DELAY_MS
+          )
+        : failureCallback(errorMessage);
+    };
+    this._tryLoad(meetingUrl, successCallback, retryOrFailureCallback);
+  }
+
+  get loaded() {
+    return this._callObjectScriptLoaded;
+  }
+
+  _tryLoad(meetingUrl, successCallback, failureCallback) {
     setUpDailyConfig();
 
     // Call object script already loaded once, so no-op.
@@ -49,9 +73,5 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
       .catch((e) => {
         failureCallback(`Failed to load call object bundle ${url}: ${e}`);
       });
-  }
-
-  get loaded() {
-    return this._callObjectScriptLoaded;
   }
 }

--- a/src/call-object-loaders/CallObjectLoaderReactNative.js
+++ b/src/call-object-loaders/CallObjectLoaderReactNative.js
@@ -18,6 +18,7 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
     super();
     this._callObjectScriptLoaded = false;
   }
+
   load(meetingUrl, _, successCallback, failureCallback) {
     setUpDailyConfig();
 
@@ -45,5 +46,9 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
       .catch((e) => {
         failureCallback(`Failed to load call object bundle ${url}: ${e}`);
       });
+  }
+
+  get loaded() {
+    return this._callObjectScriptLoaded;
   }
 }

--- a/src/call-object-loaders/CallObjectLoaderReactNative.js
+++ b/src/call-object-loaders/CallObjectLoaderReactNative.js
@@ -18,14 +18,14 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
     super();
     this._callObjectScriptLoaded = false;
   }
-  load(meetingUrl, _, callback) {
+  load(meetingUrl, _, successCallback, failureCallback) {
     setUpDailyConfig();
 
     // Call object script already loaded once, so no-op.
     // This happens after leave()ing and join()ing again.
     if (this._callObjectScriptLoaded) {
       window._dailyCallObjectSetup(EMPTY_CALL_FRAME_ID);
-      callback(true); // true = "this load() was a no-op"
+      successCallback(true); // true = "this load() was a no-op"
       return;
     }
 
@@ -40,10 +40,10 @@ export default class CallObjectLoaderReactNative extends CallObjectLoader {
       })
       .then(() => {
         this._callObjectScriptLoaded = true;
-        callback(false); // false = "this load() wasn't a no-op"
+        successCallback(false); // false = "this load() wasn't a no-op"
       })
       .catch((e) => {
-        console.error("Failed to load RN call object bundle", e);
+        failureCallback(`Failed to load call object bundle ${url}: ${e}`);
       });
   }
 }

--- a/src/call-object-loaders/CallObjectLoaderWeb.js
+++ b/src/call-object-loaders/CallObjectLoaderWeb.js
@@ -1,6 +1,9 @@
 import CallObjectLoader from "./CallObjectLoader";
 import { callObjectBundleUrl } from "../utils";
 
+const LOAD_ATTEMPTS = 3;
+const LOAD_ATTEMPT_DELAY_MS = 3000;
+
 export default class CallObjectLoaderWeb extends CallObjectLoader {
   constructor() {
     super();
@@ -8,6 +11,34 @@ export default class CallObjectLoaderWeb extends CallObjectLoader {
   }
 
   load(meetingUrl, callFrameId, successCallback, failureCallback) {
+    let attemptsRemaining = LOAD_ATTEMPTS;
+    const retryOrFailureCallback = (errorMessage) => {
+      --attemptsRemaining > 0
+        ? setTimeout(
+            () =>
+              this._tryLoad(
+                meetingUrl,
+                callFrameId,
+                successCallback,
+                retryOrFailureCallback
+              ),
+            LOAD_ATTEMPT_DELAY_MS
+          )
+        : failureCallback(errorMessage);
+    };
+    this._tryLoad(
+      meetingUrl,
+      callFrameId,
+      successCallback,
+      retryOrFailureCallback
+    );
+  }
+
+  get loaded() {
+    return this._callObjectScriptLoaded;
+  }
+
+  _tryLoad(meetingUrl, callFrameId, successCallback, failureCallback) {
     if (!document) {
       console.error("need to create call object in a DOM/web context");
       return;
@@ -35,9 +66,5 @@ export default class CallObjectLoaderWeb extends CallObjectLoader {
       script.src = callObjectBundleUrl(meetingUrl);
       head.appendChild(script);
     }
-  }
-
-  get loaded() {
-    return this._callObjectScriptLoaded;
   }
 }

--- a/src/call-object-loaders/CallObjectLoaderWeb.js
+++ b/src/call-object-loaders/CallObjectLoaderWeb.js
@@ -36,4 +36,8 @@ export default class CallObjectLoaderWeb extends CallObjectLoader {
       head.appendChild(script);
     }
   }
+
+  get loaded() {
+    return this._callObjectScriptLoaded;
+  }
 }

--- a/src/call-object-loaders/CallObjectLoaderWeb.js
+++ b/src/call-object-loaders/CallObjectLoaderWeb.js
@@ -7,14 +7,14 @@ export default class CallObjectLoaderWeb extends CallObjectLoader {
     this._callObjectScriptLoaded = false;
   }
 
-  load(meetingUrl, callFrameId, callback) {
+  load(meetingUrl, callFrameId, successCallback, failureCallback) {
     if (!document) {
       console.error("need to create call object in a DOM/web context");
       return;
     }
     if (this._callObjectScriptLoaded) {
       window._dailyCallObjectSetup(callFrameId);
-      callback(true); // true = "this load() was a no-op"
+      successCallback(true); // true = "this load() was a no-op"
     } else {
       // add a global callFrameId so we can have both iframes and one
       // call object mode calls live at the same time
@@ -27,7 +27,10 @@ export default class CallObjectLoaderWeb extends CallObjectLoader {
         script = document.createElement("script");
       script.onload = async () => {
         this._callObjectScriptLoaded = true;
-        callback(false); // false = "this load() wasn't a no-op"
+        successCallback(false); // false = "this load() wasn't a no-op"
+      };
+      script.onerror = async (e) => {
+        failureCallback(`Failed to load call object bundle ${e.target.src}`);
       };
       script.src = callObjectBundleUrl(meetingUrl);
       head.appendChild(script);

--- a/src/module.js
+++ b/src/module.js
@@ -762,7 +762,9 @@ export default class DailyIframe extends EventEmitter {
         }
         resolve();
       }
-      this.sendMessageToCallMachine({ action: DAILY_METHOD_LEAVE }, k);
+      this._callObjectLoader.loaded
+        ? this.sendMessageToCallMachine({ action: DAILY_METHOD_LEAVE }, k)
+        : k();
     });
   }
 


### PR DESCRIPTION
This PR does two things related to call object bundle loading:

- Introduces more graceful error handling when the call object bundle fails to load...
  - ...by rejecting `load()` or `startCamera()` promises
  - ...by entering the `error` meeting state
  - ...by emitting the `error` event
- Introduces retry logic to call object bundle loading

This PR does *not* yet do the following, which I think will be valuable:

- Add call object bundle caching, to avoid loads entirely in some circumstances
- Properly handle calls to `load()` (and maybe other methods) while a load is still pending. This was a potential problem before this PR, and still is.

Design choice: rather than doing some refactoring to share retry logic between RN and web, I've decided to just keep them separate for now since I can easily see those mechanisms diverging and getting more platform-specific. Happy to revisit this decision, though.

## Testing

- [x] Gracefully handle `load()` error
	- [x] RN
		- [x] Enters “error” meeting state
		- [x] `startCamera()` promise is rejected
		- [x] `join()` promise is rejected
		- [x] Can successfully re-attempt `join()` after an error
	- [x] Web
		- [x] Enters “error” meeting state
		- [x] `startCamera()` promise is rejected
		- [x] `join()` promise is rejected
		- [x] Can successfully re-attempt `join()` after an error
- [x] `load()` retries 3 times before failing
	- [x] RN
		- [x] Success on nth attempt works as expected
		- [x] Failure on nth attempt works as expected
	- [x] Web
		- [x] Success on nth attempt works as expected
		- [x] Failure on nth attempt works as expected