### PR TITLE
check the whole path to rtcType.

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -1354,7 +1354,7 @@ export default class DailyIframe extends EventEmitter {
                           // first written
     try {
       let sp = state.participants[p.session_id];
-      if (sp && sp.public.rtcType.impl === 'peer-to-peer') {
+      if (sp && sp.public && sp.public.rtcType && sp.public.rtcType.impl === 'peer-to-peer') {
         if (sp.private && !['connected', 'completed'].includes(sp.private.peeringState)) {
           connected = false;
         }


### PR DESCRIPTION
This fixes an issue where calling `addFakeParticipant` on a call object results in access of undefined. addFakeParticipant still doesn't quite work as expected, but at least now a black box for the participant appears and no errors are admitted.