### PR TITLE
[React Native] Call object bundle caching on iOS

### DIFF
--- a/src/CallObjectLoader.js
+++ b/src/CallObjectLoader.js
@@ -162,6 +162,10 @@ class LoadAttempt {
     this._networkTimedOut = false;
     this._networkTimeout = null;
 
+    this._iosCache =
+      typeof iOSCallObjectBundleCache !== "undefined" &&
+      iOSCallObjectBundleCache;
+
     this._meetingOrBaseUrl = meetingOrBaseUrl;
     this._callFrameId = callFrameId;
     this._successCallback = successCallback;
@@ -185,8 +189,7 @@ class LoadAttempt {
    */
   async _tryLoadFromIOSCache(url) {
     // console.log("[LoadAttempt] trying to load from iOS cache...");
-    const cache = window.iOSCallObjectBundleCache;
-    if (!cache) {
+    if (!this._iosCache) {
       return false;
     }
     try {
@@ -231,11 +234,13 @@ class LoadAttempt {
           throw new LoadAttemptAbortedError();
         }
         Function('"use strict";' + code)();
+        return code;
       })
-      .then(() => {
+      .then((code) => {
         if (this.cancelled) {
           throw new LoadAttemptAbortedError();
         }
+        this._iosCache && this._iosCache.set(url, code);
         this.succeeded = true;
         // console.log("[LoadAttempt] succeeded...");
         this._successCallback();

--- a/src/CallObjectLoader.js
+++ b/src/CallObjectLoader.js
@@ -192,7 +192,8 @@ class LoadAttempt {
    *
    * @param {string} url The url of the call object bundle to try to load.
    * @returns A Promise that resolves to false if the load failed or true
-   * otherwise (if it succeeded or was cancelled).
+   * otherwise (if it succeeded or was cancelled), indicating whether a network
+   * load attempt is needed.
    */
   async _tryLoadFromIOSCache(url) {
     // console.log("[LoadAttempt] trying to load from iOS cache...");
@@ -206,19 +207,20 @@ class LoadAttempt {
     try {
       const cacheResponse = await this._iosCache.get(url);
 
-      // If load has been cancelled, report work complete
+      // If load has been cancelled, report work complete (no network load 
+      // needed)
       if (this.cancelled) {
         return true;
       }
 
-      // If cache miss, report failure
+      // If cache miss, report failure (network load needed)
       if (!cacheResponse) {
         // console.log("[LoadAttempt] iOS cache miss");
         return false;
       }
 
       // If cache expired, store refetch headers to use later and report
-      // failure
+      // failure (network load needed)
       if (!cacheResponse.code) {
         // console.log(
         //   "[LoadAttempt] iOS cache expired, setting refetch headers",
@@ -229,7 +231,7 @@ class LoadAttempt {
       }
 
       // Cache is fresh, so run code and success callback, and report work
-      // complete
+      // complete (no network load needed)
       // console.log("[LoadAttempt] iOS cache hit");
       Function('"use strict";' + cacheResponse.code)();
       this.succeeded = true;


### PR DESCRIPTION
## Companion PR

https://github.com/daily-co/pluot-core/pull/1508

## Background

In React Native on iOS, I noticed that our `call-machine-object-bundle.js` wasn't ever being cached by the standard HTTP cache used by the `fetch` machinery. This meant that each time you `join()`ed a new call—between calls to `destroy()`—you'd have to first re-download the bundle.

I tracked the problem down to the fact that, since our bundle is pretty big (~3.6mb), the default iOS `URLCache` (the one used by React Native) simply opts not to cache it. Increasing the default `URLCache` size or instructing React Native to use another `URLCache` *would* resolve this problem, but React Native doesn't expose the necessary levers to do either of those things.

## Solution

So here I've implemented as barebones a custom HTTP cache as I felt was reasonable, for use in React Native running on iOS. It does the following:

* Caches `call-machine-object-bundle.js` on disk
* Respects the `max-age` provided in the `Cache-Control` header
* When the cached bundle expires, executes conditional requests using appropriate `If-None-Match` and `If-Modified-Since` headers and handles 304 responses by renewing the cache entry

## Alternatives considered

Another option was to include a bit of native code in the `react-native-daily-js` package which would increase the default `URLCache` size on iOS to a point where it would happily cache our `call-machine-object-bundle.js`. However, this is a shared cache, so upping its size would affect the entire app, and I didn't want to overstep our boundaries in that way. 

A better way would be to use a custom `URLCache` instance of this request, but that would involve making a change to (or forking) React Native and introducing an API which is not part of the `fetch()` standard...