### PR TITLE
Enable TypeScript type declarations file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // This is a work-in-progress and incomplete, and not yet exposed through
 // package.json. Use at your own risk!
 
-// Type definitions for daily-js 0.0.987
+// Type definitions for daily-js 0.9.992-beta.5
 // Project: https://github.com/daily-co/daily-js
 // Definitions by: Paul Kompfner <https://github.com/kompfner>
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/daily-co/daily-js/",
   "main": "dist/daily-iframe.js",
   "module": "dist/daily-iframe-esm.js",
+  "types": "index.d.ts",
   "files": "dist",
   "unpkg": "dist/daily-iframe.js",
   "browserslist": [


### PR DESCRIPTION
Whoops! Accidentally merged this exact change into the old default branch, `master`. Redoing it into `main`.