### PR TITLE
Avoid registering duplicate listeners on the call machine for events …

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -643,6 +643,10 @@ export default class DailyIframe extends EventEmitter {
   }
 
   async load(properties) {
+    if (!this.needsLoad()) {
+      return;
+    }
+
     if (properties) {
       this.validateProperties(properties);
       this.properties = { ...this.properties, ...properties };


### PR DESCRIPTION
…(method invocations) from daily-js if you happen to call load() again unnecessarily