### PR TITLE
Some API additions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -188,6 +188,10 @@ export interface DailyNetworkStats {
   threshold: "good" | "low" | "very-low";
 }
 
+export interface DailyPendingRoomInfo {
+  roomUrlPendingJoin: string;
+}
+
 export interface DailyRoomInfo {
   id: string;
   name: string;
@@ -304,7 +308,7 @@ export interface DailyCall {
   }>;
   requestFullscreen(): Promise<void>;
   exitFullscreen(): void;
-  room(): Promise<DailyRoomInfo | null>;
+  room(): Promise<DailyPendingRoomInfo | DailyRoomInfo | null>;
   geo(): Promise<{ current: string }>;
   setNetworkTopology(options: {
     topology: "sfu" | "peer";

--- a/src/module.js
+++ b/src/module.js
@@ -1001,7 +1001,6 @@ export default class DailyIframe extends EventEmitter {
   }
 
   async geo() {
-    methodNotSupportedInReactNative();
     return new Promise(async (resolve, _) => {
       try {
         let url = 'https://gs.daily.co/_ks_/x-swsl/:';

--- a/src/module.js
+++ b/src/module.js
@@ -986,7 +986,6 @@ export default class DailyIframe extends EventEmitter {
   }
 
   async room() {
-    methodNotSupportedInReactNative();
     if (this._meetingState !== DAILY_STATE_JOINED) {
       return null;
     }

--- a/src/module.js
+++ b/src/module.js
@@ -987,6 +987,12 @@ export default class DailyIframe extends EventEmitter {
 
   async room() {
     if (this._meetingState !== DAILY_STATE_JOINED) {
+      // Return the URL of the room we'd be in if we succesfully join()ed.
+      // Note that this doesn't mean you're necessarily in the process of
+      // joining; you might be waiting for join() to be called.
+      if (this.properties.url) {
+        return { roomUrlPendingJoin: this.properties.url };
+      }
       return null;
     }
     return new Promise((resolve, _) => {


### PR DESCRIPTION
* Enables both `geo()` and `room()` methods in React Native
* Updates `room()` to return a `roomUrlPendingJoin` while we haven't successfully joined a room

## To do after merge

- [ ] Update `daily-js` version and publish another beta
- [ ] Point `react-native-daily-js`'s `package.json` to depend on this new `daily-js` version
- [ ] Publish another `react-native-daily-js` alpha

## To do once `daily-js` is out of beta:

- [ ] Update docs to describe new `room()` behavior