### PR TITLE
allow setSubscribedTracks for local participant

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -221,9 +221,6 @@ const PARTICIPANT_PROPS = {
       if (callObject._preloadCache.subscribeToTracksAutomatically) {
         return false;
       }
-      if (participant.local) {
-        return false;
-      }
       if ([true, false, 'avatar'].includes(subs)) {
         return true;
       }
@@ -235,7 +232,7 @@ const PARTICIPANT_PROPS = {
       return true;
     },
     help:
-      'setSubscribedTracks cannot be used on the local participant, cannot be used when setSubscribeToTracksAutomatically is enabled, and should be of the form: ' +
+      'setSubscribedTracks cannot be used when setSubscribeToTracksAutomatically is enabled, and should be of the form: ' +
       "true | 'avatar' | false | { [audio: true|false], [video: true|false], [screenVideo: true|false] }",
   },
   setAudio: true,


### PR DESCRIPTION
Remove the arguments check that disallowed local video track subscription. It's not possible to subscribe to your own tracks. This has no effect in call object mode. In the prebuilt UI, if the local video cam track is subscribed to, then the local video will be displayed in the large main video panel, in addition to the normal lower left thumbnail.

```
  callObject.updateParticipant('local', {
    setSubscribedTracks: { video: true },
  });
```