### PR TITLE
'input-event' is not a type of event that can be used by consumers of…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,6 @@ export type DailyEvent =
   | 'recording-upload-completed'
   | 'recording-data'
   | 'app-message'
-  | 'input-event'
   | 'local-screen-share-started'
   | 'local-screen-share-stopped'
   | 'active-speaker-change'


### PR DESCRIPTION
… daily-js, so it shouldn't be declared in the typescript declaration file