### PR TITLE
added error message output to emit catch block

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -1466,7 +1466,7 @@ export default class DailyIframe extends EventEmitter {
         try {
           this.emit(msg.action, msg);
         } catch (e) {
-          console.log('could not emit', msg);
+          console.log('could not emit', msg, e);
         }
         break;
       case DAILY_UI_REQUEST_FULLSCREEN:


### PR DESCRIPTION
Because event handlers are called synchronously by the EventEmitter library we use, we swallow uncaught exceptions in event handler code, here. This patch adds the Error to our `console.log` to make it easier to track down exceptions in event handlers.