### PR TITLE
ENG-93 Enable localAudio() and localVideo() methods for React Native. They j…

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -524,7 +524,6 @@ export default class DailyIframe extends EventEmitter {
   }
 
   localAudio() {
-    methodNotSupportedInReactNative();
     if (this._participants.local) {
       return this._participants.local.audio;
     }
@@ -532,7 +531,6 @@ export default class DailyIframe extends EventEmitter {
   }
 
   localVideo() {
-    methodNotSupportedInReactNative();
     if (this._participants.local) {
       return this._participants.local.video;
     }


### PR DESCRIPTION
…ust work, since there's nothing native-specific about them.