### PR TITLE
ENG-241 Enable sendAppMessage() method for React Native. It just works. In SF…

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -1021,7 +1021,6 @@ export default class DailyIframe extends EventEmitter {
   }
 
   sendAppMessage(data, to = '*') {
-    methodNotSupportedInReactNative();
     if (JSON.stringify(data).length > MAX_APP_MSG_SIZE) {
       throw new Error(
         'Message data too large. Max size is ' + MAX_APP_MSG_SIZE


### PR DESCRIPTION
…U mode, an app message is just sent via web socket.

## Testing

Tested send and receive by updating RN and web demo apps to send app messages to each other via participant tile clicks. See the related PRS:

* https://github.com/daily-co/rn-daily-js-playground/pull/9
* https://github.com/daily-co/daily-demos/pull/25