### PR TITLE
Bump version to 0.9.993-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/daily-js",
-  "version": "0.9.993-beta.3",
+  "version": "0.9.993-beta.4",
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
Changes since 0.9.993-beta.3 have all been RN-related