### PR TITLE
Disable `enumerateDevices()` in RN for now, as it has no use at the m…

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -1039,6 +1039,7 @@ export default class DailyIframe extends EventEmitter {
   }
 
   async enumerateDevices() {
+    methodNotSupportedInReactNative();
     if (this._callObjectMode) {
       let raw = await navigator.mediaDevices.enumerateDevices();
       return { devices: raw.map((d) => JSON.parse(JSON.stringify(d))) };


### PR DESCRIPTION
…oment.

This is cleanup, in the interest of not keeping around methods that only serve to "clutter" the API.

Stay tuned for RN-specific TypeScript cleanup, which will come soon in a broad cleanup pass.