### PR TITLE
Fix a bug where the camera would be in a muted state after the permis…

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -1994,7 +1994,12 @@ export default class DailyIframe extends EventEmitter {
       }
     } else {
       this.camUnmutedBeforeLosingNativeActiveState = this.localVideo();
-      this.setLocalVideo(false);
+      // Mute cam, but check first whether we have local video in the first
+      // place: if we don't, we may still be in the gUM process, with the app
+      // "inactive" simply because it's behind the permissions dialogs.
+      if (this.camUnmutedBeforeLosingNativeActiveState) {
+        this.setLocalVideo(false);
+      }
     }
   };
 


### PR DESCRIPTION
…sions dialogs were shown on the first run after app installation.

This bug must've been lurking here before, but was somehow hidden before @kwindla's [improvements](https://github.com/daily-co/pluot-core/pull/1934).

## Tests

- [x] Android
  - [x] First run post-install (permissions dialogs shown)
  - [x] First run post install, with room configured to start with camera off
  - [x] Background/foreground while permissions dialog showing
  - [x] Background/foreground with video unmuted
  - [x] Background/foreground with video muted
  - [x] Background/foreground with video permission having been denied
- [x] iOS
  - [x] First run post-install (permissions dialogs shown)
  - [x] First run post install, with room configured to start with camera off
  - [x] Background/foreground while permissions dialog showing (N/A on iOS)
  - [x] Background/foreground with video unmuted
  - [x] Background/foreground with video muted
  - [x] Background/foreground with video permission having been denied