### PR TITLE
Provide a way to bypass React Native default

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -794,7 +794,15 @@ export default class DailyIframe extends EventEmitter {
     this._nativeInCallAudioMode = inCallAudioMode;
 
     // If we're in a call now, apply the new audio mode
-    if (this.shouldDeviceUseInCallAudioMode(this._meetingState)) {
+    // (assuming automatic audio device management isn't disabled)
+    const deviceManagementDisabled =
+      this.properties.reactNativeConfig &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement.audio;
+    if (
+      !deviceManagementDisabled &&
+      this.shouldDeviceUseInCallAudioMode(this._meetingState)
+    ) {
       this.nativeUtils().setAudioMode(this._nativeInCallAudioMode);
     }
 
@@ -1938,6 +1946,13 @@ export default class DailyIframe extends EventEmitter {
     if (!isReactNative()) {
       return;
     }
+    if (
+      this.properties.reactNativeConfig &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement.audio
+    ) {
+      return;
+    }
     const oldUseInCallAudioMode = this.shouldDeviceUseInCallAudioMode(
       oldMeetingState
     );
@@ -2033,6 +2048,14 @@ export default class DailyIframe extends EventEmitter {
   };
 
   handleNativeAudioFocusChange = (hasFocus) => {
+    // If automatic audio device management is disabled, bail
+    if (
+      this.properties.reactNativeConfig &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement.audio
+    ) {
+      return;
+    }
     this._hasNativeAudioFocus = hasFocus;
     // toggle participant audio if needed
     this.toggleParticipantAudioBasedOnNativeAudioFocus();

--- a/src/module.js
+++ b/src/module.js
@@ -2029,6 +2029,14 @@ export default class DailyIframe extends EventEmitter {
   }
 
   handleNativeAppActiveStateChange = (isActive) => {
+    // If automatic video device management is disabled, bail
+    if (
+      this.properties.reactNativeConfig &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement.video
+    ) {
+      return;
+    }
     if (isActive) {
       // If cam was unmuted before losing focus, unmute
       // (Note this is assumption is not perfect, since theoretically an app

--- a/src/module.js
+++ b/src/module.js
@@ -795,12 +795,8 @@ export default class DailyIframe extends EventEmitter {
 
     // If we're in a call now, apply the new audio mode
     // (assuming automatic audio device management isn't disabled)
-    const deviceManagementDisabled =
-      this.properties.reactNativeConfig &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement.audio;
     if (
-      !deviceManagementDisabled &&
+      !this.disableReactNativeAutoDeviceManagement('audio') &&
       this.shouldDeviceUseInCallAudioMode(this._meetingState)
     ) {
       this.nativeUtils().setAudioMode(this._nativeInCallAudioMode);
@@ -1943,13 +1939,9 @@ export default class DailyIframe extends EventEmitter {
   }
 
   updateDeviceAudioMode(oldMeetingState) {
-    if (!isReactNative()) {
-      return;
-    }
     if (
-      this.properties.reactNativeConfig &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement.audio
+      !isReactNative() ||
+      this.disableReactNativeAutoDeviceManagement('audio')
     ) {
       return;
     }
@@ -2030,11 +2022,7 @@ export default class DailyIframe extends EventEmitter {
 
   handleNativeAppActiveStateChange = (isActive) => {
     // If automatic video device management is disabled, bail
-    if (
-      this.properties.reactNativeConfig &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement.video
-    ) {
+    if (this.disableReactNativeAutoDeviceManagement('video')) {
       return;
     }
     if (isActive) {
@@ -2057,11 +2045,7 @@ export default class DailyIframe extends EventEmitter {
 
   handleNativeAudioFocusChange = (hasFocus) => {
     // If automatic audio device management is disabled, bail
-    if (
-      this.properties.reactNativeConfig &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
-      this.properties.reactNativeConfig.disableAutoDeviceManagement.audio
-    ) {
+    if (this.disableReactNativeAutoDeviceManagement('audio')) {
       return;
     }
     this._hasNativeAudioFocus = hasFocus;
@@ -2098,6 +2082,15 @@ export default class DailyIframe extends EventEmitter {
         streamData.pendingTrack.enabled = this._hasNativeAudioFocus;
       }
     }
+  }
+
+  // type must be either 'audio' or 'video'
+  disableReactNativeAutoDeviceManagement(type) {
+    return (
+      this.properties.reactNativeConfig &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement &&
+      this.properties.reactNativeConfig.disableAutoDeviceManagement[type]
+    );
   }
 
   absoluteUrl(url) {


### PR DESCRIPTION
By default, `react-native-daily-js` does a few things automatically that fall under the umbrella of "automatic device management":
1. Picking an audio device automatically based on what devices are available and what the customer has specified as the "in-call audio mode" (defaulting to "video" but changeable to "voice" with the `setNativeInCallAudioMode()` method)
2. Muting or unmuting the mic based on whether app has audio focus (Android only)
3. Muting or unmuting the camera based on whether the app is in the background

There are at least some customer use-cases where overriding these behaviors might be desirable:
* Controlling audio route selection in native code (which would require bypassing 1)
* Using a framework like ConnectionService on Android to help you determine audio focus (which would require bypassing 2)
* Continuing video in the background, at least on Android (bypass 3)

There may be more. Seems worth having in place up-front to give savvy customers workarounds if needed.