### PR TITLE
Include daily-js version in pluot-core Sentry errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -407,6 +407,7 @@ export interface DailyCallFactory {
 
 export interface DailyCallStaticUtils {
   supportedBrowser(): DailyBrowserInfo;
+  version(): string;
 }
 
 export interface DailyCall {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
 import commonJS from 'rollup-plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
+import { version } from './package-lock.json';
 
 const production = process.env.NODE_ENV || 'production';
 
@@ -16,6 +17,7 @@ export default [
       }),
       replace({
         'process.env.NODE_ENV': JSON.stringify(production),
+        __dailyJsVersion__: JSON.stringify(version),
       }),
       babel({
         exclude: 'node_modules/**',

--- a/src/module.js
+++ b/src/module.js
@@ -226,6 +226,9 @@ const FRAME_PROPS = {
   embHref: {
     queryString: 'embHref',
   },
+  dailyJsVersion: {
+    queryString: 'dailyJsVersion',
+  },
 };
 
 // todo: more validation?
@@ -294,11 +297,15 @@ const PARTICIPANT_PROPS = {
 
 export default class DailyIframe extends EventEmitter {
   //
-  // browser support check
+  // static methods
   //
 
   static supportedBrowser() {
     return browserInfo();
+  }
+
+  static version() {
+    return __dailyJsVersion__;
   }
 
   //
@@ -415,6 +422,7 @@ export default class DailyIframe extends EventEmitter {
 
   constructor(iframeish, properties = {}) {
     super();
+    properties.dailyJsVersion = __dailyJsVersion__;
     this._iframe = iframeish;
     this._callObjectMode = properties.layout === 'none' && !this._iframe;
     this._preloadCache = initializePreloadCache();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const version = require('./package-lock.json').version;
 const mode = process.env.NODE_ENV || 'production';
 
 const bundle = {
@@ -20,6 +21,7 @@ const bundle = {
       'process.env': {
         NODE_ENV: JSON.stringify(mode),
       },
+      __dailyJsVersion__: JSON.stringify(version),
     }),
   ],
   module: {


### PR DESCRIPTION
See companion PR