### PR TITLE
ENG-729 Add option to hide avatar bar/local video in calls

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -508,6 +508,8 @@ export interface DailyCall {
   sendAppMessage(data: any, to?: string): DailyCall;
   addFakeParticipant(details?: { aspectRatio: number }): DailyCall;
   setShowNamesMode(mode: false | 'always' | 'never'): DailyCall;
+  showLocalVideo(bool: boolean): DailyCall;
+  showParticipantsBar(bool: boolean): DailyCall;
   detectAllFaces(): Promise<{
     faces?: { [id: string]: DailyFaceInfo[] };
   }>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -512,6 +512,8 @@ export interface DailyCall {
   setShowNamesMode(mode: false | 'always' | 'never'): DailyCall;
   setShowLocalVideo(show: boolean): DailyCall;
   setShowParticipantsBar(show: boolean): DailyCall;
+  showLocalVideo(): boolean;
+  showParticipantsBar(): boolean;
   detectAllFaces(): Promise<{
     faces?: { [id: string]: DailyFaceInfo[] };
   }>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -98,6 +98,8 @@ export interface DailyCallOptions {
   token?: string;
   lang?: DailyLanguage;
   showLeaveButton?: boolean;
+  showParticipantsBar?: boolean;
+  showLocalVideo?: boolean;
   showFullscreenButton?: boolean;
   iframeStyle?: CSSStyleDeclaration;
   customLayout?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -508,8 +508,8 @@ export interface DailyCall {
   sendAppMessage(data: any, to?: string): DailyCall;
   addFakeParticipant(details?: { aspectRatio: number }): DailyCall;
   setShowNamesMode(mode: false | 'always' | 'never'): DailyCall;
-  showLocalVideo(bool: boolean): DailyCall;
-  showParticipantsBar(bool: boolean): DailyCall;
+  setShowLocalVideo(show: boolean): DailyCall;
+  setShowParticipantsBar(show: boolean): DailyCall;
   detectAllFaces(): Promise<{
     faces?: { [id: string]: DailyFaceInfo[] };
   }>;

--- a/src/module.js
+++ b/src/module.js
@@ -1236,10 +1236,14 @@ export default class DailyIframe extends EventEmitter {
     return this;
   }
 
-  showLocalVideo(bool = true) {
+  setShowLocalVideo(bool = true) {
     methodNotSupportedInReactNative();
     if (typeof bool !== 'boolean') {
-      console.error('showLocalVideo only accepts a boolean value');
+      console.error('setShowLocalVideo only accepts a boolean value');
+      return this;
+    }
+    if (this._callObjectMode) {
+      console.error('setShowLocalVideo is not available in callObject mode');
       return this;
     }
     this.sendMessageToCallMachine({
@@ -1249,9 +1253,16 @@ export default class DailyIframe extends EventEmitter {
     return this;
   }
 
-  showParticipantsBar(bool = true) {
+  setShowParticipantsBar(bool = true) {
+    methodNotSupportedInReactNative();
     if (typeof bool !== 'boolean') {
-      console.error('showParticipantsBar only accepts a boolean value');
+      console.error('setShowParticipantsBar only accepts a boolean value');
+      return this;
+    }
+    if (this._callObjectMode) {
+      console.error(
+        'setShowParticipantsBar is not available in callObject mode'
+      );
       return this;
     }
     this.sendMessageToCallMachine({

--- a/src/module.js
+++ b/src/module.js
@@ -1001,6 +1001,8 @@ export default class DailyIframe extends EventEmitter {
           }
         }
       }
+      properties.showLocalVideo = this._showLocalVideo;
+      properties.showParticipantsBar = this._showParticipantsBar;
 
       // Validate and assign properties to this.properties, for use by call
       // machine
@@ -1250,6 +1252,12 @@ export default class DailyIframe extends EventEmitter {
       console.error('setShowLocalVideo is not available in callObject mode');
       return this;
     }
+    if (this._meetingState !== DAILY_STATE_JOINED) {
+      console.error(
+        'the meeting must be joined before calling setShowLocalVideo'
+      );
+      return this;
+    }
     this.sendMessageToCallMachine({
       action: DAILY_METHOD_SET_SHOW_LOCAL_VIDEO,
       bool,
@@ -1272,6 +1280,12 @@ export default class DailyIframe extends EventEmitter {
     if (this._callObjectMode) {
       console.error(
         'setShowParticipantsBar is not available in callObject mode'
+      );
+      return this;
+    }
+    if (this._meetingState !== DAILY_STATE_JOINED) {
+      console.error(
+        'the meeting must be joined before calling setShowParticipantsBar'
       );
       return this;
     }

--- a/src/module.js
+++ b/src/module.js
@@ -474,8 +474,20 @@ export default class DailyIframe extends EventEmitter {
     this._messageChannel = isReactNative()
       ? new ReactNativeMessageChannel()
       : new WebMessageChannel();
-    this._showLocalVideo = properties.showLocalVideo;
-    this._showParticipantsBar = properties.showParticipantsBar;
+
+    if (this._callObjectMode) {
+      if (properties.showLocalVideo !== undefined) {
+        console.error('showLocalVideo is not available in callObject mode');
+      }
+      if (properties.showParticipantsBar !== undefined) {
+        console.error(
+          'showParticipantsBar is not available in callObject mode'
+        );
+      }
+    } else {
+      this._showLocalVideo = properties.showLocalVideo;
+      this._showParticipantsBar = properties.showParticipantsBar;
+    }
 
     // fullscreen event listener
     if (this._iframe) {

--- a/src/module.js
+++ b/src/module.js
@@ -461,6 +461,8 @@ export default class DailyIframe extends EventEmitter {
     this._network = { threshold: 'good', quality: 100 };
     this._activeSpeaker = {};
     this._activeSpeakerMode = false;
+    this._showLocalVideo = true;
+    this._showParticipantsBar = true;
     this._callFrameId = Date.now() + Math.random().toString();
     this._messageChannel = isReactNative()
       ? new ReactNativeMessageChannel()
@@ -1250,7 +1252,13 @@ export default class DailyIframe extends EventEmitter {
       action: DAILY_METHOD_SET_SHOW_LOCAL_VIDEO,
       bool,
     });
+    this._showLocalVideo = bool;
     return this;
+  }
+
+  showLocalVideo() {
+    methodNotSupportedInReactNative();
+    return this._showLocalVideo;
   }
 
   setShowParticipantsBar(bool = true) {
@@ -1269,7 +1277,13 @@ export default class DailyIframe extends EventEmitter {
       action: DAILY_METHOD_SET_SHOW_PARTICIPANTS_BAR,
       bool,
     });
+    this._showParticipantsBar = bool;
     return this;
+  }
+
+  showParticipantsBar() {
+    methodNotSupportedInReactNative();
+    return this._showParticipantsBar;
   }
 
   detectAllFaces() {

--- a/src/module.js
+++ b/src/module.js
@@ -75,6 +75,8 @@ import {
   DAILY_METHOD_APP_MSG,
   DAILY_METHOD_ADD_FAKE_PARTICIPANT,
   DAILY_METHOD_SET_SHOW_NAMES,
+  DAILY_METHOD_SHOW_LOCAL_VIDEO,
+  DAILY_METHOD_SHOW_PARTICIPANTS_BAR,
   DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE,
   DAILY_METHOD_SET_LANG,
   MAX_APP_MSG_SIZE,
@@ -1230,6 +1232,31 @@ export default class DailyIframe extends EventEmitter {
     this.sendMessageToCallMachine({
       action: DAILY_METHOD_SET_SHOW_NAMES,
       mode: mode,
+    });
+    return this;
+  }
+
+  showLocalVideo(bool = true) {
+    methodNotSupportedInReactNative();
+    if (typeof bool !== 'boolean') {
+      console.error('showLocalVideo only accepts a boolean value');
+      return this;
+    }
+    this.sendMessageToCallMachine({
+      action: DAILY_METHOD_SHOW_LOCAL_VIDEO,
+      bool,
+    });
+    return this;
+  }
+
+  showParticipantsBar(bool) {
+    if (typeof bool !== 'boolean') {
+      console.error('showParticipantsBar only accepts a boolean value');
+      return this;
+    }
+    this.sendMessageToCallMachine({
+      action: DAILY_METHOD_SHOW_PARTICIPANTS_BAR,
+      bool,
     });
     return this;
   }

--- a/src/module.js
+++ b/src/module.js
@@ -201,6 +201,8 @@ const FRAME_PROPS = {
   },
   userName: true, // ignored if there's a token
   showLeaveButton: true,
+  showLocalVideo: true,
+  showParticipantsBar: true,
   showFullscreenButton: true,
   // style to apply to iframe in createFrame factory method
   iframeStyle: true,

--- a/src/module.js
+++ b/src/module.js
@@ -389,6 +389,14 @@ export default class DailyIframe extends EventEmitter {
         };
       }
     }
+    // default the local video + participants bar display to true if not specified
+    if (properties.showLocalVideo === undefined) {
+      properties.showLocalVideo = true;
+    }
+    if (properties.showParticipantsBar === undefined) {
+      properties.showParticipantsBar = true;
+    }
+
     let iframeEl = document.createElement('iframe');
     // special-case for old Electron for Figma
     if (window.navigator && window.navigator.userAgent.match(/Chrome\/61\./)) {
@@ -462,12 +470,12 @@ export default class DailyIframe extends EventEmitter {
     this._network = { threshold: 'good', quality: 100 };
     this._activeSpeaker = {};
     this._activeSpeakerMode = false;
-    this._showLocalVideo = true;
-    this._showParticipantsBar = true;
     this._callFrameId = Date.now() + Math.random().toString();
     this._messageChannel = isReactNative()
       ? new ReactNativeMessageChannel()
       : new WebMessageChannel();
+    this._showLocalVideo = properties.showLocalVideo;
+    this._showParticipantsBar = properties.showParticipantsBar;
 
     // fullscreen event listener
     if (this._iframe) {
@@ -1007,8 +1015,13 @@ export default class DailyIframe extends EventEmitter {
       this.properties = { ...this.properties, ...properties };
     }
 
-    this._showLocalVideo = properties.showLocalVideo;
-    this._showParticipantsBar = properties.showParticipantsBar;
+    // only update if showLocalVideo/showParticipantsBar are being explicitly set
+    if (properties.showLocalVideo !== undefined) {
+      this._showLocalVideo = !!properties.showLocalVideo;
+    }
+    if (properties.showParticipantsBar !== undefined) {
+      this._showParticipantsBar = !!properties.showParticipantsBar;
+    }
 
     if (
       this._meetingState === DAILY_STATE_JOINED ||

--- a/src/module.js
+++ b/src/module.js
@@ -1017,10 +1017,20 @@ export default class DailyIframe extends EventEmitter {
 
     // only update if showLocalVideo/showParticipantsBar are being explicitly set
     if (properties.showLocalVideo !== undefined) {
-      this._showLocalVideo = !!properties.showLocalVideo;
+      if (this._callObjectMode) {
+        console.error('showLocalVideo is not available in callObject mode');
+      } else {
+        this._showLocalVideo = !!properties.showLocalVideo;
+      }
     }
     if (properties.showParticipantsBar !== undefined) {
-      this._showParticipantsBar = !!properties.showParticipantsBar;
+      if (this._callObjectMode) {
+        console.error(
+          'showParticipantsBar is not available in callObject mode'
+        );
+      } else {
+        this._showParticipantsBar = !!properties.showParticipantsBar;
+      }
     }
 
     if (
@@ -1282,6 +1292,10 @@ export default class DailyIframe extends EventEmitter {
 
   showLocalVideo() {
     methodNotSupportedInReactNative();
+    if (this._callObjectMode) {
+      console.error('showLocalVideo is not available in callObject mode');
+      return this;
+    }
     return this._showLocalVideo;
   }
 
@@ -1313,6 +1327,10 @@ export default class DailyIframe extends EventEmitter {
 
   showParticipantsBar() {
     methodNotSupportedInReactNative();
+    if (this._callObjectMode) {
+      console.error('showParticipantsBar is not available in callObject mode');
+      return this;
+    }
     return this._showParticipantsBar;
   }
 

--- a/src/module.js
+++ b/src/module.js
@@ -389,13 +389,6 @@ export default class DailyIframe extends EventEmitter {
         };
       }
     }
-    // default the local video + participants bar display to true if not specified
-    if (properties.showLocalVideo === undefined) {
-      properties.showLocalVideo = true;
-    }
-    if (properties.showParticipantsBar === undefined) {
-      properties.showParticipantsBar = true;
-    }
 
     let iframeEl = document.createElement('iframe');
     // special-case for old Electron for Figma
@@ -457,6 +450,29 @@ export default class DailyIframe extends EventEmitter {
     if (this._callObjectMode) {
       window._dailyPreloadCache = this._preloadCache;
     }
+
+    if (properties.showLocalVideo !== undefined) {
+      if (this._callObjectMode) {
+        console.error('showLocalVideo is not available in callObject mode');
+      } else {
+        this._showLocalVideo = !!properties.showLocalVideo;
+      }
+    } else {
+      this._showLocalVideo = true;
+    }
+
+    if (properties.showParticipantsBar !== undefined) {
+      if (this._callObjectMode) {
+        console.error(
+          'showParticipantsBar is not available in callObject mode'
+        );
+      } else {
+        this._showParticipantsBar = !!properties.showParticipantsBar;
+      }
+    } else {
+      this._showParticipantsBar = true;
+    }
+
     this.validateProperties(properties);
     this.properties = { ...properties };
     this._callObjectLoader = this._callObjectMode
@@ -474,20 +490,6 @@ export default class DailyIframe extends EventEmitter {
     this._messageChannel = isReactNative()
       ? new ReactNativeMessageChannel()
       : new WebMessageChannel();
-
-    if (this._callObjectMode) {
-      if (properties.showLocalVideo !== undefined) {
-        console.error('showLocalVideo is not available in callObject mode');
-      }
-      if (properties.showParticipantsBar !== undefined) {
-        console.error(
-          'showParticipantsBar is not available in callObject mode'
-        );
-      }
-    } else {
-      this._showLocalVideo = properties.showLocalVideo;
-      this._showParticipantsBar = properties.showParticipantsBar;
-    }
 
     // fullscreen event listener
     if (this._iframe) {

--- a/src/module.js
+++ b/src/module.js
@@ -75,8 +75,8 @@ import {
   DAILY_METHOD_APP_MSG,
   DAILY_METHOD_ADD_FAKE_PARTICIPANT,
   DAILY_METHOD_SET_SHOW_NAMES,
-  DAILY_METHOD_SHOW_LOCAL_VIDEO,
-  DAILY_METHOD_SHOW_PARTICIPANTS_BAR,
+  DAILY_METHOD_SET_SHOW_LOCAL_VIDEO,
+  DAILY_METHOD_SET_SHOW_PARTICIPANTS_BAR,
   DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE,
   DAILY_METHOD_SET_LANG,
   MAX_APP_MSG_SIZE,
@@ -1243,7 +1243,7 @@ export default class DailyIframe extends EventEmitter {
       return this;
     }
     this.sendMessageToCallMachine({
-      action: DAILY_METHOD_SHOW_LOCAL_VIDEO,
+      action: DAILY_METHOD_SET_SHOW_LOCAL_VIDEO,
       bool,
     });
     return this;
@@ -1255,7 +1255,7 @@ export default class DailyIframe extends EventEmitter {
       return this;
     }
     this.sendMessageToCallMachine({
-      action: DAILY_METHOD_SHOW_PARTICIPANTS_BAR,
+      action: DAILY_METHOD_SET_SHOW_PARTICIPANTS_BAR,
       bool,
     });
     return this;

--- a/src/module.js
+++ b/src/module.js
@@ -1249,7 +1249,7 @@ export default class DailyIframe extends EventEmitter {
     return this;
   }
 
-  showParticipantsBar(bool) {
+  showParticipantsBar(bool = true) {
     if (typeof bool !== 'boolean') {
       console.error('showParticipantsBar only accepts a boolean value');
       return this;

--- a/src/module.js
+++ b/src/module.js
@@ -449,7 +449,6 @@ export default class DailyIframe extends EventEmitter {
     if (this._callObjectMode) {
       window._dailyPreloadCache = this._preloadCache;
     }
-
     this.validateProperties(properties);
     this.properties = { ...properties };
     this._callObjectLoader = this._callObjectMode
@@ -1001,14 +1000,16 @@ export default class DailyIframe extends EventEmitter {
           }
         }
       }
-      properties.showLocalVideo = this._showLocalVideo;
-      properties.showParticipantsBar = this._showParticipantsBar;
 
       // Validate and assign properties to this.properties, for use by call
       // machine
       this.validateProperties(properties);
       this.properties = { ...this.properties, ...properties };
     }
+
+    this._showLocalVideo = properties.showLocalVideo;
+    this._showParticipantsBar = properties.showParticipantsBar;
+
     if (
       this._meetingState === DAILY_STATE_JOINED ||
       this._meetingState === DAILY_STATE_JOINING
@@ -1242,9 +1243,9 @@ export default class DailyIframe extends EventEmitter {
     return this;
   }
 
-  setShowLocalVideo(bool = true) {
+  setShowLocalVideo(show = true) {
     methodNotSupportedInReactNative();
-    if (typeof bool !== 'boolean') {
+    if (typeof show !== 'boolean') {
       console.error('setShowLocalVideo only accepts a boolean value');
       return this;
     }
@@ -1260,9 +1261,9 @@ export default class DailyIframe extends EventEmitter {
     }
     this.sendMessageToCallMachine({
       action: DAILY_METHOD_SET_SHOW_LOCAL_VIDEO,
-      bool,
+      show,
     });
-    this._showLocalVideo = bool;
+    this._showLocalVideo = show;
     return this;
   }
 
@@ -1271,9 +1272,9 @@ export default class DailyIframe extends EventEmitter {
     return this._showLocalVideo;
   }
 
-  setShowParticipantsBar(bool = true) {
+  setShowParticipantsBar(show = true) {
     methodNotSupportedInReactNative();
-    if (typeof bool !== 'boolean') {
+    if (typeof show !== 'boolean') {
       console.error('setShowParticipantsBar only accepts a boolean value');
       return this;
     }
@@ -1291,9 +1292,9 @@ export default class DailyIframe extends EventEmitter {
     }
     this.sendMessageToCallMachine({
       action: DAILY_METHOD_SET_SHOW_PARTICIPANTS_BAR,
-      bool,
+      show,
     });
-    this._showParticipantsBar = bool;
+    this._showParticipantsBar = show;
     return this;
   }
 

--- a/src/shared-with-pluot-core/CommonIncludes.js
+++ b/src/shared-with-pluot-core/CommonIncludes.js
@@ -92,6 +92,9 @@ export const DAILY_METHOD_GET_CAMERA_FACING_MODE = 'get-camera-facing-mode';
 export const DAILY_METHOD_APP_MSG = 'app-msg';
 export const DAILY_METHOD_ADD_FAKE_PARTICIPANT = 'add-fake-participant';
 export const DAILY_METHOD_SET_SHOW_NAMES = 'set-show-names';
+export const DAILY_METHOD_SET_SHOW_LOCAL_VIDEO = 'set-local-video-display';
+export const DAILY_METHOD_SET_SHOW_PARTICIPANTS_BAR =
+  'set-thumbnail-bar-display';
 export const DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE = 'set-active-speaker-mode';
 export const DAILY_METHOD_REGISTER_INPUT_HANDLER = 'register-input-handler';
 export const DAILY_METHOD_SET_LANG = 'set-daily-lang';

--- a/src/shared-with-pluot-core/CommonIncludes.js
+++ b/src/shared-with-pluot-core/CommonIncludes.js
@@ -92,9 +92,9 @@ export const DAILY_METHOD_GET_CAMERA_FACING_MODE = 'get-camera-facing-mode';
 export const DAILY_METHOD_APP_MSG = 'app-msg';
 export const DAILY_METHOD_ADD_FAKE_PARTICIPANT = 'add-fake-participant';
 export const DAILY_METHOD_SET_SHOW_NAMES = 'set-show-names';
-export const DAILY_METHOD_SET_SHOW_LOCAL_VIDEO = 'set-local-video-display';
+export const DAILY_METHOD_SET_SHOW_LOCAL_VIDEO = 'set-show-local-video';
 export const DAILY_METHOD_SET_SHOW_PARTICIPANTS_BAR =
-  'set-participants-bar-display';
+  'set-show-participants-bar';
 export const DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE = 'set-active-speaker-mode';
 export const DAILY_METHOD_REGISTER_INPUT_HANDLER = 'register-input-handler';
 export const DAILY_METHOD_SET_LANG = 'set-daily-lang';

--- a/src/shared-with-pluot-core/CommonIncludes.js
+++ b/src/shared-with-pluot-core/CommonIncludes.js
@@ -94,7 +94,7 @@ export const DAILY_METHOD_ADD_FAKE_PARTICIPANT = 'add-fake-participant';
 export const DAILY_METHOD_SET_SHOW_NAMES = 'set-show-names';
 export const DAILY_METHOD_SET_SHOW_LOCAL_VIDEO = 'set-local-video-display';
 export const DAILY_METHOD_SET_SHOW_PARTICIPANTS_BAR =
-  'set-thumbnail-bar-display';
+  'set-participants-bar-display';
 export const DAILY_METHOD_SET_ACTIVE_SPEAKER_MODE = 'set-active-speaker-mode';
 export const DAILY_METHOD_REGISTER_INPUT_HANDLER = 'register-input-handler';
 export const DAILY_METHOD_SET_LANG = 'set-daily-lang';


### PR DESCRIPTION
There are 2 PRs for this feature (`pluot-core` and `daily-js`). https://github.com/daily-co/pluot-core/pull/2326

Changes:
- add method `showParticipantsBar` to DailtyIframe, which accepts a boolean value (default `true`). I changed the phrase to be "participants bar" instead of "thumbnail" or "avatar" bar after chatting with Steve and Phil. This is the phrase we'll be using in the rewrite to be more consistent with our docs.
- add method `showLocalVideo` to DailtyIframe, which accepts a boolean value (default `true`).

