### PR TITLE
Updating CSS style interface to not require all properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ export interface DailyCallOptions {
   showParticipantsBar?: boolean;
   showLocalVideo?: boolean;
   showFullscreenButton?: boolean;
-  iframeStyle?: CSSStyleDeclaration;
+  iframeStyle?: Partial<CSSStyleDeclaration>;
   customLayout?: boolean;
   bodyClass?: string;
   cssFile?: string;
@@ -208,9 +208,9 @@ export interface DailyParticipantCss {
 }
 
 export interface DailyParticipantStreamCss {
-  div?: CSSStyleDeclaration;
-  overlay?: CSSStyleDeclaration;
-  video?: CSSStyleDeclaration;
+  div?: Partial<CSSStyleDeclaration>;
+  overlay?: Partial<CSSStyleDeclaration>;
+  video?: Partial<CSSStyleDeclaration>;
 }
 
 export interface DailyVideoElementInfo {


### PR DESCRIPTION
I'm guessing you don't want me to have to enter definitions for all 390 css properties. :)
![screenshot](https://i.ibb.co/5vVjLPg/image.png)

So this should be `Partial<CSSStyleDeclaration>`