### PR TITLE
ENG-823 Remove main branch instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,3 @@
 
 - [Javascript docs](https://docs.daily.co/reference#using-the-dailyco-front-end-library): To add video calls to web pages and mobile apps
 - [REST API docs](https://docs.daily.co/reference): To create video call rooms, configure features for the rooms, and manage users and permissions
-
-**A note on the default branch name**
-
-For anyone currently depending on bleeding-edge, not-yet-published changes in `daily-js`: the name of the default branch where these changes land is **`main`**. Please make sure your `package.json` reflects this.
-
-```json
-{
-  "dependencies": {
-    "@daily-co/daily-js": "daily-co/daily-js#main"
-  }
-}
-```


### PR DESCRIPTION
Excluding these instructions for using the main branch of daily-js since `main` won't work as is right now. Open to suggestions if anyone would prefer a rephrasing, though.

Btw, I tried running `npm run build` from within `node_modules/@daily-co/daily-js` and I get webpack errors, so that's why I lean towards removing vs. making the instructions more specific.