### PR TITLE
add persistentTrack field as a sibling to track

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -250,6 +250,7 @@ export interface DailyTrackState {
     byBandwidth?: boolean;
   };
   track?: MediaStreamTrack;
+  persistentTrack?: MediaStreamTrack;
 }
 
 export interface DailyParticipant {


### PR DESCRIPTION
Looks like a DailyTrackState should have a persistentTrack property so that intermediate black frames can be smoothed over.  This section of the docs says to prefer it over `track`:

https://docs.daily.co/reference/daily-js/instance-methods/participants#participant-properties

Let me know if I misinterpreted and this field would be better off somewhere else!