### PR TITLE
chore: add error message when using custom iframe without right allow value

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -172,6 +172,8 @@ import {
   isReactNative,
   browserVideoSupported_p,
   getUserAgent,
+  iframeAllowValue,
+  isChromeV61,
   isFullscreenSupported,
   isScreenSharingSupported,
   isSfuSupported,
@@ -732,6 +734,17 @@ export default class DailyIframe extends EventEmitter {
         properties.layout = 'browser';
       }
     }
+    if (
+      !(isChromeV61()
+        ? /(?=.*microphone)(?=.*camera)/.test(iframeish.allow)
+        : /(?=.*microphone)(?=.*camera)(?=.*autoplay)(?=.*display-capture)/.test(
+            iframeish.allow
+          ))
+    ) {
+      console.error(
+        `The iframe's "allow" property should contain the following values: ${iframeAllowValue()}`
+      );
+    }
     return new DailyIframe(iframeish, properties);
   }
 
@@ -770,12 +783,7 @@ export default class DailyIframe extends EventEmitter {
     }
 
     let iframeEl = document.createElement('iframe');
-    // special-case for old Electron for Figma
-    if (window.navigator && window.navigator.userAgent.match(/Chrome\/61\./)) {
-      iframeEl.allow = 'microphone, camera';
-    } else {
-      iframeEl.allow = 'microphone; camera; autoplay; display-capture';
-    }
+    iframeEl.allow = iframeAllowValue();
     iframeEl.style.visibility = 'hidden';
     parentEl.appendChild(iframeEl);
     iframeEl.style.visibility = null;

--- a/src/shared-with-pluot-core/Environment.js
+++ b/src/shared-with-pluot-core/Environment.js
@@ -355,3 +355,14 @@ export function isCurrentDailyJsNearEndOfSupport() {
     NEARING_EOS_DAILY_JS_VERSION
   );
 }
+
+export function isChromeV61() {
+  return window.navigator?.userAgent.match(/Chrome\/61\./);
+}
+
+export function iframeAllowValue() {
+  // special-case for old Electron for Figma
+  return isChromeV61()
+    ? 'microphone, camera'
+    : 'microphone; camera; autoplay; display-capture';
+}


### PR DESCRIPTION
I used `@daily-co/daily-js` for a POC as a possible replacement of Twilio.
I quickly got it running by using my own `<iframe />` (using `wrap()`, not `createFrame()`), but I was seeing a message asking to allow mic and camera in the browser, even though the permissions were properly set already.

<img width="725" alt="Screen Shot 2022-08-05 at 11 15 10" src="https://user-images.githubusercontent.com/37919309/183303051-e3ae77a5-8307-4bc9-b51b-9bd300ec4c7f.png">

I opened the dev tools, but couldn't easily find what was happening.

<img width="747" alt="Screen Shot 2022-08-05 at 11 39 50" src="https://user-images.githubusercontent.com/37919309/183303084-ebce762b-bb3e-4928-a965-49db265c3b08.png">

Then, comparing my iframe with the one created by `createFrame()`, I realized my iframe was lacking the `allow` property with the right permissions.

This PR is a proposal contribution to make the developer's experience more straightforward in cases like this.