### PR TITLE
fix: make local optional in typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,7 @@ export type DailyNonFatalErrorType =
 export type DailyNetworkTopology = 'sfu' | 'peer';
 
 export interface DailyParticipantsObject {
-  local: DailyParticipant;
+  local?: DailyParticipant;
   [id: string]: DailyParticipant;
 }
 


### PR DESCRIPTION
@lazeratops and I noticed that `local` is sometimes `undefined`. Currently our workaround is to add a `//@ts-ignore` in the project we're working on. This should fix this issue.