### PR TITLE
fix: Adding enable_dialout to DailyRoomInfo typing interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -961,6 +961,7 @@ export interface DailyRoomInfo {
     audio_only?: boolean;
     enable_recording?: string;
     enable_dialin?: boolean;
+    enable_dialout?: boolean;
     /**
      * @deprecated This property will be removed.
      * All calls are treated as autojoin.


### PR DESCRIPTION
There's the `enable_dialin` boolean as well as the `enable_dialout` one.  The former is in this interface; this PR adds the latter

![image](https://github.com/user-attachments/assets/ec12692f-e8f7-48c1-9c1a-142463f798e2)
